### PR TITLE
Task/randomize buttons

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
-status: Ready to plan
-stopped_at: Completed quick-01-PLAN.md
-last_updated: "2026-04-06T15:24:25.689Z"
+status: In progress
+stopped_at: Completed task/randomize-buttons branch work
+last_updated: "2026-04-07T00:00:00.000Z"
 progress:
   total_phases: 6
   completed_phases: 2
@@ -16,7 +16,7 @@ progress:
 
 ## Current Phase
 
-Phase 1: Foundation & Application Shell
+Phase 2: Core Map Generation — UI enhancements on branch `task/randomize-buttons`
 
 ## Status Updates
 
@@ -26,12 +26,20 @@ Phase 1: Foundation & Application Shell
 
 ## Session Info
 
-**Stopped at:** Completed quick-01-PLAN.md
-**Resume file:** None
-**Last activity:** 2026-04-06 - Completed quick task 260406-o1n: refactor the ui back to what we had, but keep the map editor and make the map zoomable
+**Stopped at:** Completed task/randomize-buttons branch work
+**Resume file:** Branch `task/randomize-buttons` — merge to main when ready
+**Last activity:** 2026-04-07 - Completed task/randomize-buttons: tab rename, Random Seed button, Randomize Settings button
 
 ### Quick Tasks Completed
 
 | # | Description | Date | Commit | Directory |
 |---|-------------|------|--------|-----------|
 | 260406-o1n | refactor the ui back to what we had, but keep the map editor and make the map zoomable | 2026-04-06 | 28a5b3c | [260406-o1n-refactor-the-ui-back-to-what-we-had-but-](./quick/260406-o1n-refactor-the-ui-back-to-what-we-had-but-/) |
+
+### Task Branch Commits (task/randomize-buttons)
+
+| # | Description | Commit |
+|---|-------------|--------|
+| 1 | Rename generator tabs to World, POIs, Kingdoms | 595c2bf |
+| 2 | Add Random Seed button generating random 8-digit number | 370ca5f |
+| 3 | Add Randomize Settings button to randomize all slider values | e4aa091 |

--- a/src/main/java/com/mapbuilder/mapbuilder/core/MVPBase.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/core/MVPBase.java
@@ -17,6 +17,8 @@ public interface MVPBase {
         Slider getTempBiasSlider();
         Slider getRainBiasSlider();
         Button getRandomSeedButton();
+        Button getGenerateButton();
+        Button getRandomizeSettingsButton();
     }
 
     interface Presenter<V extends View> {

--- a/src/main/java/com/mapbuilder/mapbuilder/core/MVPBase.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/core/MVPBase.java
@@ -1,6 +1,7 @@
 package com.mapbuilder.mapbuilder.core;
 
 import javafx.scene.canvas.Canvas;
+import javafx.scene.control.Button;
 import javafx.scene.control.Slider;
 import javafx.scene.control.TextField;
 
@@ -15,6 +16,7 @@ public interface MVPBase {
         Slider getWaterLevelSlider();
         Slider getTempBiasSlider();
         Slider getRainBiasSlider();
+        Button getRandomSeedButton();
     }
 
     interface Presenter<V extends View> {

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -11,6 +11,8 @@ import javafx.scene.image.PixelFormat;
 import javafx.scene.image.PixelWriter;
 import javafx.util.Duration;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 public class MainPresenter implements MVPBase.Presenter<MainView> {
     
     private MainView view;
@@ -36,6 +38,10 @@ public class MainPresenter implements MVPBase.Presenter<MainView> {
     }
 
     private void bind() {
+        view.getRandomSeedButton().setOnAction(e -> {
+            int randomSeed = ThreadLocalRandom.current().nextInt(10000000, 100000000);
+            view.getSeedField().setText(String.valueOf(randomSeed));
+        });
         view.getSizeSlider().valueProperty().addListener((obs, oldV, newV) -> triggerGeneration());
         view.getOctavesSlider().valueProperty().addListener((obs, oldV, newV) -> triggerGeneration());
         view.getScaleSlider().valueProperty().addListener((obs, oldV, newV) -> triggerGeneration());

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -42,6 +42,8 @@ public class MainPresenter implements MVPBase.Presenter<MainView> {
             int randomSeed = ThreadLocalRandom.current().nextInt(10000000, 100000000);
             view.getSeedField().setText(String.valueOf(randomSeed));
         });
+        view.getGenerateButton().setOnAction(e -> triggerGeneration());
+        view.getRandomizeSettingsButton().setOnAction(e -> randomizeSettings());
         view.getSizeSlider().valueProperty().addListener((obs, oldV, newV) -> triggerGeneration());
         view.getOctavesSlider().valueProperty().addListener((obs, oldV, newV) -> triggerGeneration());
         view.getScaleSlider().valueProperty().addListener((obs, oldV, newV) -> triggerGeneration());
@@ -54,6 +56,18 @@ public class MainPresenter implements MVPBase.Presenter<MainView> {
 
     private void triggerGeneration() {
         debounce.playFromStart();
+    }
+
+    private void randomizeSettings() {
+        ThreadLocalRandom rand = ThreadLocalRandom.current();
+        view.getSizeSlider().setValue(rand.nextInt(200, 2001));
+        view.getOctavesSlider().setValue(rand.nextInt(1, 11));
+        view.getScaleSlider().setValue(rand.nextDouble(0.001, 0.05));
+        view.getFalloffSlider().setValue(rand.nextDouble(-1.0, 1.0));
+        view.getWaterLevelSlider().setValue(rand.nextDouble(-1.0, 1.0));
+        view.getTempBiasSlider().setValue(rand.nextDouble(-0.5, 0.5));
+        view.getRainBiasSlider().setValue(rand.nextDouble(-0.5, 0.5));
+        triggerGeneration();
     }
 
     private void generateMapAsync() {

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -25,6 +25,7 @@ public class MainView extends AnchorPane implements MVPBase.View {
     private final Canvas canvas;
     private final Pane canvasContainer;
     private final TextField seedField;
+    private final Button randomSeedButton;
     
     private final Slider sizeSlider;
     private final Slider octavesSlider;
@@ -103,6 +104,12 @@ public class MainView extends AnchorPane implements MVPBase.View {
         tabPane.setStyle("-fx-background-color: transparent;");
 
         seedField = new TextField("12345");
+        seedField.setPrefWidth(100);
+        randomSeedButton = new Button("Random Seed");
+        randomSeedButton.setStyle("-fx-cursor: hand;");
+        HBox seedRow = new HBox(8);
+        seedRow.setAlignment(Pos.CENTER_LEFT);
+        seedRow.getChildren().addAll(new Label("Seed"), seedField, randomSeedButton);
         
         sizeSlider = new Slider(200, 2000, 800);
         sizeSlider.setShowTickMarks(true);
@@ -143,7 +150,7 @@ public class MainView extends AnchorPane implements MVPBase.View {
 
         leftPanel.getChildren().addAll(
             headerBox,
-            new Label("Seed"), seedField,
+            seedRow,
             tabPane,
             new Label("Map Size"), sizeSlider,
             new Label("Octaves (Detail Level)"), octavesSlider,
@@ -266,4 +273,6 @@ public class MainView extends AnchorPane implements MVPBase.View {
     public Slider getTempBiasSlider() { return tempBiasSlider; }
     @Override
     public Slider getRainBiasSlider() { return rainBiasSlider; }
+    @Override
+    public Button getRandomSeedButton() { return randomSeedButton; }
 }

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -99,7 +99,7 @@ public class MainView extends AnchorPane implements MVPBase.View {
         HBox.setHgrow(spacer, javafx.scene.layout.Priority.ALWAYS);
         headerBox.getChildren().addAll(headerLabel, spacer, collapseLeftBtn);
 
-        TabPane tabPane = new TabPane(new Tab("Tab 1"), new Tab("Tab 2"));
+        TabPane tabPane = new TabPane(new Tab("World"), new Tab("POIs"), new Tab("Kingdoms"));
         tabPane.setStyle("-fx-background-color: transparent;");
 
         seedField = new TextField("12345");

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -34,6 +34,8 @@ public class MainView extends AnchorPane implements MVPBase.View {
     private final Slider waterLevelSlider;
     private final Slider tempBiasSlider;
     private final Slider rainBiasSlider;
+    private final Button generateButton;
+    private final Button randomizeSettingsButton;
 
     public MainView() {
         // Center Panel (Canvas Container) - Now at the back of the AnchorPane
@@ -148,6 +150,11 @@ public class MainView extends AnchorPane implements MVPBase.View {
         rainBiasSlider.setShowTickLabels(true);
         rainBiasSlider.setMajorTickUnit(0.25);
 
+        generateButton = new Button("Generate");
+        randomizeSettingsButton = new Button("Randomize Settings");
+        HBox actionRow = new HBox(8);
+        actionRow.getChildren().addAll(generateButton, randomizeSettingsButton);
+
         leftPanel.getChildren().addAll(
             headerBox,
             seedRow,
@@ -159,7 +166,7 @@ public class MainView extends AnchorPane implements MVPBase.View {
             new Label("Sea Level"), waterLevelSlider,
             new Label("Temperature Bias"), tempBiasSlider,
             new Label("Rainfall Bias"), rainBiasSlider,
-            new Button("Generate")
+            new HBox(8, generateButton, randomizeSettingsButton)
         );
         
         ScrollPane leftScroll = new ScrollPane(leftPanel);
@@ -275,4 +282,8 @@ public class MainView extends AnchorPane implements MVPBase.View {
     public Slider getRainBiasSlider() { return rainBiasSlider; }
     @Override
     public Button getRandomSeedButton() { return randomSeedButton; }
+    @Override
+    public Button getGenerateButton() { return generateButton; }
+    @Override
+    public Button getRandomizeSettingsButton() { return randomizeSettingsButton; }
 }


### PR DESCRIPTION
## Summary

UI enhancements to the generator settings panel — renamed tabs, added random seed generation, and added a button to randomize all slider settings at once.

## Changes

- **Tab rename:** Replaced generic "Tab 1"/"Tab 2" placeholders with "World", "POIs", "Kingdoms" (removed "Streets & Rivers" as requested)
- **Random Seed button:** Added next to the seed text field — generates a random 8-digit number on each click
- **Randomize Settings button:** Added next to the Generate button — randomizes all slider values within their configured ranges and triggers a regeneration
- **STATE.md updated:** Tracked all commits in `.planning/STATE.md` for GSD context continuity

## Files Modified

- `MainView.java` — New buttons, seed row layout, action row layout, new getters
- `MVPBase.java` — Added `getRandomSeedButton()`, `getGenerateButton()`, `getRandomizeSettingsButton()` to View interface
- `MainPresenter.java` — Wired Random Seed, Generate, and Randomize Settings button actions
- `.planning/STATE.md` — Updated progress tracking

## Commits

1. `595c2bf` — ui: rename generator tabs to World, POIs, Kingdoms
2. `370ca5f` — ui: add Random Seed button generating random 8-digit number
3. `e4aa091` — ui: add Randomize Settings button to randomize all slider values
4. `c84609a` — docs: update STATE.md with task/randomize-buttons progress
