### PR TITLE
Prevent infinite stretch artifacts

### DIFF
--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -398,7 +398,9 @@ public class MainPresenter {
         }
 
         GraphicsContext gc = canvas.getGraphicsContext2D();
-        gc.clearRect(0, 0, canvasW, canvasH);
+        // Fill out-of-bounds space with DEEP_OCEAN color
+        gc.setFill(javafx.scene.paint.Color.web("#00008B"));
+        gc.fillRect(0, 0, canvasW, canvasH);
         
         // Determine active image: cached LOD image or base map image fallback
         LodRegion region = computeRequiredLOD(canvasW, canvasH, baseGrid);
@@ -423,8 +425,25 @@ public class MainPresenter {
             sourceH = canvasH / pixelsPerCell;
         }
 
-        // Draw hardware-accelerated image
-        gc.drawImage(activeImage, sourceX, sourceY, sourceW, sourceH, 0, 0, canvasW, canvasH);
+        double imgW = activeImage.getWidth();
+        double imgH = activeImage.getHeight();
+
+        // Calculate intersection to avoid stretching artifacts
+        double intersectX = Math.max(0, sourceX);
+        double intersectY = Math.max(0, sourceY);
+        double intersectW = Math.min(imgW - intersectX, sourceW - (intersectX - sourceX));
+        double intersectH = Math.min(imgH - intersectY, sourceH - (intersectY - sourceY));
+
+        if (intersectW > 0 && intersectH > 0) {
+            // Map cropped source coordinates to destination coordinates
+            double destX = (intersectX - sourceX) * (canvasW / sourceW);
+            double destY = (intersectY - sourceY) * (canvasH / sourceH);
+            double destW = intersectW * (canvasW / sourceW);
+            double destH = intersectH * (canvasH / sourceH);
+
+            // Draw hardware-accelerated image properly cropped
+            gc.drawImage(activeImage, intersectX, intersectY, intersectW, intersectH, destX, destY, destW, destH);
+        }
         
         renderPOIs();
         renderLabels();
@@ -659,7 +678,7 @@ public class MainPresenter {
 
     private int getColorAt(int cx, int cy, MapGrid grid, boolean showBorders, boolean showOverlay) {
         if (cx < 0 || cx >= grid.getWidth() || cy < 0 || cy >= grid.getHeight()) {
-            return 0xFF333333;
+            return 0xFF00008B;
         }
         MapCell cell = grid.getCell(cx, cy);
         int color = cell.getMixedColorARGB();


### PR DESCRIPTION
closes #36 

This pull request improves the rendering logic in the `MainPresenter` to better handle out-of-bounds areas and image cropping, resulting in more visually accurate map displays. The changes ensure that areas outside the map are filled with a consistent deep ocean color and that the map image is drawn without stretching artifacts when the visible region extends beyond the image boundaries.

**Rendering improvements:**

* The background of the map canvas is now filled with a deep ocean color (`#00008B`) to visually distinguish out-of-bounds areas.
* The color returned for out-of-bounds grid cells in the color cache is changed to match the deep ocean color, ensuring consistency between the rendered map and the color cache.

**Image drawing and cropping:**

* The logic for drawing the map image has been updated to calculate the intersection between the requested source area and the actual image bounds, preventing stretching artifacts when the view extends outside the image. The destination coordinates are adjusted accordingly to ensure only valid image data is drawn.