### PR TITLE
Feature/prov grenz edit

### DIFF
--- a/src/main/java/com/mapbuilder/mapbuilder/core/map/Kingdom.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/core/map/Kingdom.java
@@ -4,14 +4,19 @@ public class Kingdom {
     private int id;
     private int colorARGB;
     private MapCell capital;
+    private String name;
 
     public Kingdom(int id, int colorARGB, MapCell capital) {
         this.id = id;
         this.colorARGB = colorARGB;
         this.capital = capital;
+        this.name = "Province " + (id + 1);
     }
 
-    public int getId() { return id; }
-    public int getColorARGB() { return colorARGB; }
-    public MapCell getCapital() { return capital; }
+    public int getId()                       { return id; }
+    public int getColorARGB()               { return colorARGB; }
+    public void setColorARGB(int colorARGB) { this.colorARGB = colorARGB; }
+    public MapCell getCapital()              { return capital; }
+    public String getName()                  { return name; }
+    public void setName(String name)         { this.name = name; }
 }

--- a/src/main/java/com/mapbuilder/mapbuilder/core/map/MapGrid.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/core/map/MapGrid.java
@@ -8,12 +8,14 @@ public class MapGrid {
     private final int height;
     private final MapCell[][] grid;
     private List<PointOfInterest> pois;
+    private List<Kingdom> kingdoms;
 
     public MapGrid(int width, int height) {
         this.width = width;
         this.height = height;
         this.grid = new MapCell[width][height];
         this.pois = new ArrayList<>();
+        this.kingdoms = new ArrayList<>();
 
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
@@ -78,5 +80,15 @@ public class MapGrid {
             }
         }
         return null;
+    }
+
+    /** Returns all kingdoms registered on this map. */
+    public List<Kingdom> getKingdoms() {
+        return kingdoms;
+    }
+
+    /** Replaces the kingdoms list. Called by KingdomPass after generation. */
+    public void setKingdoms(List<Kingdom> kingdoms) {
+        this.kingdoms = kingdoms != null ? kingdoms : new ArrayList<>();
     }
 }

--- a/src/main/java/com/mapbuilder/mapbuilder/core/map/generator/KingdomPass.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/core/map/generator/KingdomPass.java
@@ -29,7 +29,13 @@ public class KingdomPass implements MapGenerationPass {
 
     @Override
     public void execute(MapGrid grid, GenerationParameters params) {
-        if (params.kingdomCount() <= 0) return;
+        if (params.kingdomCount() <= 0) {
+            grid.setKingdoms(new ArrayList<>());
+            for (int x = 0; x < grid.getWidth(); x++)
+                for (int y = 0; y < grid.getHeight(); y++)
+                    grid.getCell(x, y).setKingdom(null);
+            return;
+        }
 
         int width = grid.getWidth();
         int height = grid.getHeight();
@@ -117,5 +123,6 @@ public class KingdomPass implements MapGenerationPass {
                 }
             }
         }
+        grid.setKingdoms(kingdoms);
     }
 }

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -150,6 +150,11 @@ public class MainPresenter {
         });
         
         view.getCanvasContainer().setOnMouseReleased(event -> {
+            if (provincePaintMode && event.getButton() == javafx.scene.input.MouseButton.PRIMARY) {
+                lastPaintX = -1;
+                lastPaintY = -1;
+                annexEnclosedAreas();
+            }
             draggedLabel = null;
         });
 
@@ -1112,5 +1117,81 @@ public class MainPresenter {
         // Invalidate LOD cache so zoomed-out views get the new pixels too
         lodImageCache.clear();
         renderMap();
+    }
+
+    private void annexEnclosedAreas() {
+        MapGrid grid = model.getCurrentGrid();
+        if (grid == null || selectedPaintKingdom == null) return;
+
+        int w = grid.getWidth();
+        int h = grid.getHeight();
+        boolean[][] reachesEdge = new boolean[w][h];
+        java.util.Queue<int[]> queue = new java.util.LinkedList<>();
+
+        // 1. Add all edge cells that are not selectedPaintKingdom
+        for (int x = 0; x < w; x++) {
+            if (grid.getCell(x, 0).getKingdom() != selectedPaintKingdom) {
+                reachesEdge[x][0] = true;
+                queue.add(new int[]{x, 0});
+            }
+            if (grid.getCell(x, h - 1).getKingdom() != selectedPaintKingdom) {
+                reachesEdge[x][h - 1] = true;
+                queue.add(new int[]{x, h - 1});
+            }
+        }
+        for (int y = 0; y < h; y++) {
+            if (grid.getCell(0, y).getKingdom() != selectedPaintKingdom) {
+                reachesEdge[0][y] = true;
+                queue.add(new int[]{0, y});
+            }
+            if (grid.getCell(w - 1, y).getKingdom() != selectedPaintKingdom) {
+                reachesEdge[w - 1][y] = true;
+                queue.add(new int[]{w - 1, y});
+            }
+        }
+
+        // 2. Flood fill
+        int[] dx = {-1, 1, 0, 0};
+        int[] dy = {0, 0, -1, 1};
+        while (!queue.isEmpty()) {
+            int[] p = queue.poll();
+            int cx = p[0], cy = p[1];
+            for (int i = 0; i < 4; i++) {
+                int nx = cx + dx[i];
+                int ny = cy + dy[i];
+                if (nx >= 0 && nx < w && ny >= 0 && ny < h) {
+                    if (!reachesEdge[nx][ny] && grid.getCell(nx, ny).getKingdom() != selectedPaintKingdom) {
+                        reachesEdge[nx][ny] = true;
+                        queue.add(new int[]{nx, ny});
+                    }
+                }
+            }
+        }
+
+        // 3. Annex cells that couldn't reach the edge
+        boolean changed = false;
+        double waterLevel = view.getWaterLevelSlider().getValue();
+        int minX = Integer.MAX_VALUE, minY = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE, maxY = Integer.MIN_VALUE;
+
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                if (!reachesEdge[x][y]) {
+                    MapCell cell = grid.getCell(x, y);
+                    if (cell.getKingdom() != selectedPaintKingdom && cell.getElevation() > waterLevel) {
+                        cell.setKingdom(selectedPaintKingdom);
+                        minX = Math.min(minX, x);
+                        minY = Math.min(minY, y);
+                        maxX = Math.max(maxX, x);
+                        maxY = Math.max(maxY, y);
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        if (changed) {
+            updateImagePixels(minX, minY, maxX, maxY);
+        }
     }
 }

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -1,5 +1,6 @@
 package com.mapbuilder.mapbuilder.main;
 
+import com.mapbuilder.mapbuilder.core.map.Kingdom;
 import com.mapbuilder.mapbuilder.core.map.LodGridCache;
 import com.mapbuilder.mapbuilder.core.map.LodLevel;
 import com.mapbuilder.mapbuilder.core.map.LodRegion;
@@ -9,6 +10,7 @@ import com.mapbuilder.mapbuilder.core.map.MapGrid;
 import com.mapbuilder.mapbuilder.core.map.PointOfInterest;
 import com.mapbuilder.mapbuilder.ui.POIEditorDialog;
 import com.mapbuilder.mapbuilder.ui.POIIconMapper;
+import com.mapbuilder.mapbuilder.ui.ProvinceListPanel;
 import javafx.animation.PauseTransition;
 import javafx.application.Platform;
 import javafx.concurrent.Task;
@@ -58,6 +60,10 @@ public class MainPresenter {
     private final MapGenerator lodGenerator = new MapGenerator();
     private LodLevel activeLodLevel = LodLevel.LOD_0;
 
+    // Province editing
+    private boolean provincePaintMode = false;
+    private Kingdom selectedPaintKingdom = null;
+
     public MainPresenter() {
         this.model = new MainModel();
         this.debounce = new PauseTransition(Duration.millis(300));
@@ -69,6 +75,7 @@ public class MainPresenter {
     public void setView(MainView view) {
         this.view = view;
         view.getPOIListPanel().setPresenter(this);
+        view.getProvinceListPanel().setPresenter(this);
         bind();
         triggerGeneration();
     }
@@ -89,6 +96,12 @@ public class MainPresenter {
         
         view.getCanvasContainer().setOnMousePressed(event -> {
             view.getCanvasContainer().requestFocus();
+            // Province paint mode — paint cells on press
+            if (provincePaintMode && event.getButton() == javafx.scene.input.MouseButton.PRIMARY) {
+                paintCellsAtScreen(event.getX(), event.getY());
+                event.consume();
+                return;
+            }
             if (event.getButton() == javafx.scene.input.MouseButton.PRIMARY) {
                 double x = event.getX();
                 double y = event.getY();
@@ -104,6 +117,12 @@ public class MainPresenter {
         });
         
         view.getCanvasContainer().setOnMouseDragged(event -> {
+            // Province paint mode — paint cells while dragging
+            if (provincePaintMode && event.getButton() == javafx.scene.input.MouseButton.PRIMARY) {
+                paintCellsAtScreen(event.getX(), event.getY());
+                event.consume();
+                return;
+            }
             if (draggedLabel != null) {
                 double worldX = viewOffsetX + event.getX() / pixelsPerCell;
                 double worldY = viewOffsetY + event.getY() / pixelsPerCell;
@@ -155,7 +174,7 @@ public class MainPresenter {
             double y = event.getY();
             com.mapbuilder.mapbuilder.core.map.MapLabel clickedLabel = getLabelAt(x, y);
 
-            if (event.getClickCount() == 2) {
+            if (event.getClickCount() == 2 && !provincePaintMode) {
                 if (clickedLabel != null) {
                     final com.mapbuilder.mapbuilder.core.map.MapLabel finalLabel = clickedLabel;
                     if (event.getButton() == javafx.scene.input.MouseButton.SECONDARY) {
@@ -190,10 +209,25 @@ public class MainPresenter {
                 if (clickedLabel != null) {
                      confirmAndRemoveLabel(clickedLabel);
                 }
+            } else if (event.getButton() == javafx.scene.input.MouseButton.PRIMARY
+                    && event.getClickCount() == 1 && !provincePaintMode) {
+                // Single left-click in normal mode: select the province under the cursor
+                if (clickedLabel == null) {
+                    Kingdom k = getKingdomAtScreen(x, y);
+                    if (k != null) setSelectedKingdom(k);
+                }
             }
         });
         
         setupPOIDensityListeners();
+
+        // Province paint mode toggle
+        view.getProvincePaintToggle().selectedProperty().addListener((obs, oldV, newV) -> {
+            provincePaintMode = newV;
+            view.getCanvasContainer().setCursor(
+                    newV ? javafx.scene.Cursor.CROSSHAIR : javafx.scene.Cursor.DEFAULT);
+            if (!newV) selectedPaintKingdom = null;
+        });
     }
 
     private com.mapbuilder.mapbuilder.core.map.MapLabel getLabelAt(double screenX, double screenY) {
@@ -451,6 +485,7 @@ public class MainPresenter {
         renderPOIs();
         renderLabels();
         view.getPOIListPanel().updatePOIList(baseGrid.getPointsOfInterest());
+        view.getProvinceListPanel().updateProvinceList(baseGrid.getKingdoms());
     }
 
     private void renderLabels() {
@@ -906,5 +941,69 @@ public class MainPresenter {
         grid.removePointOfInterest(poi.getId());
         renderMap();
     }
-}
 
+    // ── Province Editing ─────────────────────────────────────────────────────
+
+    /**
+     * Called by {@link com.mapbuilder.mapbuilder.ui.ProvinceListPanel} whenever a
+     * province colour is changed via the inline {@code ColorPicker}.
+     * Rebuilds the cached map image so the new colour is immediately visible.
+     */
+    public void onProvinceColorChanged() {
+        regenerateImages();
+    }
+
+    /**
+     * Marks {@code kingdom} as the province to paint and highlights it in the
+     * province list panel.
+     */
+    public void setSelectedKingdom(Kingdom kingdom) {
+        selectedPaintKingdom = kingdom;
+        view.getProvinceListPanel().selectKingdom(kingdom);
+    }
+
+    /**
+     * Returns the {@link Kingdom} whose territory covers the given screen
+     * position, or {@code null} if the position is over water or outside the map.
+     */
+    private Kingdom getKingdomAtScreen(double screenX, double screenY) {
+        MapGrid grid = model.getCurrentGrid();
+        if (grid == null) return null;
+        int cx = (int) (viewOffsetX + screenX / pixelsPerCell);
+        int cy = (int) (viewOffsetY + screenY / pixelsPerCell);
+        MapCell cell = grid.getCell(cx, cy);
+        return cell != null ? cell.getKingdom() : null;
+    }
+
+    /**
+     * Paints all land cells within the brush radius around the given screen
+     * position to {@link #selectedPaintKingdom}.
+     * Only land cells (elevation > waterLevel) are reassigned.
+     */
+    private void paintCellsAtScreen(double screenX, double screenY) {
+        MapGrid grid = model.getCurrentGrid();
+        if (grid == null || selectedPaintKingdom == null) return;
+
+        double waterLevel = view.getWaterLevelSlider().getValue();
+        int cx = (int) (viewOffsetX + screenX / pixelsPerCell);
+        int cy = (int) (viewOffsetY + screenY / pixelsPerCell);
+        int radius = (int) view.getBrushSizeSlider().getValue();
+
+        boolean changed = false;
+        for (int dx = -radius; dx <= radius; dx++) {
+            for (int dy = -radius; dy <= radius; dy++) {
+                if (dx * dx + dy * dy <= radius * radius) {
+                    MapCell cell = grid.getCell(cx + dx, cy + dy);
+                    if (cell != null && cell.getElevation() > waterLevel) {
+                        cell.setKingdom(selectedPaintKingdom);
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        if (changed) {
+            regenerateImages();
+        }
+    }
+}

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -63,6 +63,8 @@ public class MainPresenter {
     // Province editing
     private boolean provincePaintMode = false;
     private Kingdom selectedPaintKingdom = null;
+    private double lastPaintX = -1;
+    private double lastPaintY = -1;
 
     public MainPresenter() {
         this.model = new MainModel();
@@ -98,6 +100,8 @@ public class MainPresenter {
             view.getCanvasContainer().requestFocus();
             // Province paint mode — paint cells on press
             if (provincePaintMode && event.getButton() == javafx.scene.input.MouseButton.PRIMARY) {
+                lastPaintX = event.getX();
+                lastPaintY = event.getY();
                 paintCellsAtScreen(event.getX(), event.getY());
                 event.consume();
                 return;
@@ -119,7 +123,13 @@ public class MainPresenter {
         view.getCanvasContainer().setOnMouseDragged(event -> {
             // Province paint mode — paint cells while dragging
             if (provincePaintMode && event.getButton() == javafx.scene.input.MouseButton.PRIMARY) {
-                paintCellsAtScreen(event.getX(), event.getY());
+                if (lastPaintX >= 0 && lastPaintY >= 0) {
+                    paintCellsBetweenScreen(lastPaintX, lastPaintY, event.getX(), event.getY());
+                } else {
+                    paintCellsAtScreen(event.getX(), event.getY());
+                }
+                lastPaintX = event.getX();
+                lastPaintY = event.getY();
                 event.consume();
                 return;
             }
@@ -995,13 +1005,55 @@ public class MainPresenter {
                 if (dx * dx + dy * dy <= radius * radius) {
                     MapCell cell = grid.getCell(cx + dx, cy + dy);
                     if (cell != null && cell.getElevation() > waterLevel) {
-                        cell.setKingdom(selectedPaintKingdom);
-                        changed = true;
+                        if (cell.getKingdom() != selectedPaintKingdom) {
+                            cell.setKingdom(selectedPaintKingdom);
+                            changed = true;
+                        }
                     }
                 }
             }
         }
 
+        if (changed) {
+            regenerateImages();
+        }
+    }
+
+    private void paintCellsBetweenScreen(double x0, double y0, double x1, double y1) {
+        MapGrid grid = model.getCurrentGrid();
+        if (grid == null || selectedPaintKingdom == null) return;
+
+        double waterLevel = view.getWaterLevelSlider().getValue();
+        int radius = (int) view.getBrushSizeSlider().getValue();
+        
+        double dist = Math.hypot(x1 - x0, y1 - y0);
+        // Paint every pixel cell step to ensure no gaps
+        int steps = (int) Math.max(1, dist / (pixelsPerCell * Math.max(0.5, radius * 0.5)));
+        
+        boolean changed = false;
+        for (int i = 0; i <= steps; i++) {
+            double t = (double) i / steps;
+            double sx = x0 + t * (x1 - x0);
+            double sy = y0 + t * (y1 - y0);
+            
+            int cx = (int) (viewOffsetX + sx / pixelsPerCell);
+            int cy = (int) (viewOffsetY + sy / pixelsPerCell);
+            
+            for (int dx = -radius; dx <= radius; dx++) {
+                for (int dy = -radius; dy <= radius; dy++) {
+                    if (dx * dx + dy * dy <= radius * radius) {
+                        MapCell cell = grid.getCell(cx + dx, cy + dy);
+                        if (cell != null && cell.getElevation() > waterLevel) {
+                            if (cell.getKingdom() != selectedPaintKingdom) {
+                                cell.setKingdom(selectedPaintKingdom);
+                                changed = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
         if (changed) {
             regenerateImages();
         }

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -236,7 +236,14 @@ public class MainPresenter {
             provincePaintMode = newV;
             view.getCanvasContainer().setCursor(
                     newV ? javafx.scene.Cursor.CROSSHAIR : javafx.scene.Cursor.DEFAULT);
-            if (!newV) selectedPaintKingdom = null;
+            if (!newV) setSelectedKingdom(null);
+        });
+
+        // Automatically turn off paint mode when leaving the Kingdoms tab
+        view.getKingdomsTab().selectedProperty().addListener((obs, oldV, newV) -> {
+            if (!newV) {
+                view.getProvincePaintToggle().setSelected(false);
+            }
         });
     }
 
@@ -970,6 +977,13 @@ public class MainPresenter {
     public void setSelectedKingdom(Kingdom kingdom) {
         selectedPaintKingdom = kingdom;
         view.getProvinceListPanel().selectKingdom(kingdom);
+        if (kingdom != null) {
+            view.getSelectedProvinceLabel().setText(kingdom.getName());
+            view.getSelectedProvinceColorBox().setFill(toFXColor(kingdom.getColorARGB()));
+        } else {
+            view.getSelectedProvinceLabel().setText("None");
+            view.getSelectedProvinceColorBox().setFill(javafx.scene.paint.Color.TRANSPARENT);
+        }
     }
 
     /**
@@ -1000,6 +1014,11 @@ public class MainPresenter {
         int radius = (int) view.getBrushSizeSlider().getValue();
 
         boolean changed = false;
+        int minX = Integer.MAX_VALUE;
+        int minY = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE;
+        int maxY = Integer.MIN_VALUE;
+
         for (int dx = -radius; dx <= radius; dx++) {
             for (int dy = -radius; dy <= radius; dy++) {
                 if (dx * dx + dy * dy <= radius * radius) {
@@ -1007,6 +1026,10 @@ public class MainPresenter {
                     if (cell != null && cell.getElevation() > waterLevel) {
                         if (cell.getKingdom() != selectedPaintKingdom) {
                             cell.setKingdom(selectedPaintKingdom);
+                            minX = Math.min(minX, cx + dx);
+                            minY = Math.min(minY, cy + dy);
+                            maxX = Math.max(maxX, cx + dx);
+                            maxY = Math.max(maxY, cy + dy);
                             changed = true;
                         }
                     }
@@ -1015,7 +1038,7 @@ public class MainPresenter {
         }
 
         if (changed) {
-            regenerateImages();
+            updateImagePixels(minX, minY, maxX, maxY);
         }
     }
 
@@ -1031,6 +1054,11 @@ public class MainPresenter {
         int steps = (int) Math.max(1, dist / (pixelsPerCell * Math.max(0.5, radius * 0.5)));
         
         boolean changed = false;
+        int minX = Integer.MAX_VALUE;
+        int minY = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE;
+        int maxY = Integer.MIN_VALUE;
+
         for (int i = 0; i <= steps; i++) {
             double t = (double) i / steps;
             double sx = x0 + t * (x1 - x0);
@@ -1046,6 +1074,10 @@ public class MainPresenter {
                         if (cell != null && cell.getElevation() > waterLevel) {
                             if (cell.getKingdom() != selectedPaintKingdom) {
                                 cell.setKingdom(selectedPaintKingdom);
+                                minX = Math.min(minX, cx + dx);
+                                minY = Math.min(minY, cy + dy);
+                                maxX = Math.max(maxX, cx + dx);
+                                maxY = Math.max(maxY, cy + dy);
                                 changed = true;
                             }
                         }
@@ -1055,7 +1087,30 @@ public class MainPresenter {
         }
         
         if (changed) {
-            regenerateImages();
+            updateImagePixels(minX, minY, maxX, maxY);
         }
+    }
+
+    private void updateImagePixels(int minX, int minY, int maxX, int maxY) {
+        MapGrid grid = model.getCurrentGrid();
+        if (grid == null || baseMapImage == null) return;
+        boolean showBorders = view.getEnableBordersToggle().isSelected();
+        boolean showOverlay = view.getEnableKingdomOverlayToggle().isSelected();
+        
+        // Expand bounding box slightly for borders
+        minX = Math.max(0, minX - 1);
+        minY = Math.max(0, minY - 1);
+        maxX = Math.min(grid.getWidth() - 1, maxX + 1);
+        maxY = Math.min(grid.getHeight() - 1, maxY + 1);
+        
+        PixelWriter writer = baseMapImage.getPixelWriter();
+        for (int cy = minY; cy <= maxY; cy++) {
+            for (int cx = minX; cx <= maxX; cx++) {
+                writer.setArgb(cx, cy, getColorAt(cx, cy, grid, showBorders, showOverlay));
+            }
+        }
+        // Invalidate LOD cache so zoomed-out views get the new pixels too
+        lodImageCache.clear();
+        renderMap();
     }
 }

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -213,8 +213,6 @@ public class MainView extends AnchorPane {
         kingdomsTab.setContent(kingdomsContent);
 
         // ── Province Editing section (added to same kingdoms VBox) ──────────
-        Label provSepLabel = new Label("\u2500\u2500 Province Editing \u2500\u2500");
-        provSepLabel.setStyle("-fx-text-fill: #888888; -fx-font-size: 11px;");
 
         provincePaintToggle = new ToggleButton("\uD83C\uDFA8  Province Paint Mode");
         provincePaintToggle.setId("province-paint-toggle");
@@ -244,7 +242,6 @@ public class MainView extends AnchorPane {
 
         kingdomsContent.getChildren().addAll(
                 new Separator(),
-                provSepLabel,
                 provincePaintToggle,
                 selectedProvinceBox,
                 brushSizeLabel, brushSizeSlider,

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -54,6 +54,7 @@ public class MainView extends AnchorPane {
     private CheckBox enableBordersToggle;
     private CheckBox enableKingdomOverlayToggle;
     private ToggleButton poiToggle;
+    private Tab kingdomsTab;
     
     private Slider dungeonDensitySlider;
     private Slider settlementDensitySlider;
@@ -65,6 +66,8 @@ public class MainView extends AnchorPane {
     private ProvinceListPanel provinceListPanel;
     private ToggleButton provincePaintToggle;
     private Slider brushSizeSlider;
+    private Label selectedProvinceLabel;
+    private javafx.scene.shape.Rectangle selectedProvinceColorBox;
 
     public MainView() {
         setupCanvasContainer();
@@ -176,7 +179,7 @@ public class MainView extends AnchorPane {
         );
         hydrologyTab.setContent(hydrologyContent);
 
-        Tab kingdomsTab = new Tab("Kingdoms");
+        kingdomsTab = new Tab("Kingdoms");
         kingdomsTab.setClosable(false);
         kingdomsTab.setStyle("-fx-text-fill: white;");
         VBox kingdomsContent = new VBox(10);
@@ -217,6 +220,14 @@ public class MainView extends AnchorPane {
         provincePaintToggle.setId("province-paint-toggle");
         provincePaintToggle.setMaxWidth(Double.MAX_VALUE);
 
+        selectedProvinceLabel = new Label("Selected: None");
+        selectedProvinceLabel.setStyle("-fx-text-fill: white; -fx-font-style: italic;");
+        selectedProvinceColorBox = new javafx.scene.shape.Rectangle(12, 12, javafx.scene.paint.Color.TRANSPARENT);
+        selectedProvinceColorBox.setStroke(javafx.scene.paint.Color.WHITE);
+        HBox selectedProvinceBox = new HBox(5, new Label("Paint Target:"), selectedProvinceColorBox, selectedProvinceLabel);
+        selectedProvinceBox.setAlignment(Pos.CENTER_LEFT);
+        selectedProvinceBox.setStyle("-fx-text-fill: white;");
+
         Label brushSizeLabel = new Label("Brush Size");
         brushSizeLabel.setStyle("-fx-text-fill: white;");
         brushSizeSlider = new Slider(1, 15, 3);
@@ -235,6 +246,7 @@ public class MainView extends AnchorPane {
                 new Separator(),
                 provSepLabel,
                 provincePaintToggle,
+                selectedProvinceBox,
                 brushSizeLabel, brushSizeSlider,
                 new Separator(),
                 provListTitle,
@@ -562,6 +574,9 @@ public class MainView extends AnchorPane {
     public POIListPanel getPOIListPanel() { return poiListPanel; }
 
     public ToggleButton getProvincePaintToggle()    { return provincePaintToggle; }
+    public Tab getKingdomsTab()                     { return kingdomsTab; }
     public Slider       getBrushSizeSlider()        { return brushSizeSlider; }
     public ProvinceListPanel getProvinceListPanel() { return provinceListPanel; }
+    public Label getSelectedProvinceLabel()         { return selectedProvinceLabel; }
+    public javafx.scene.shape.Rectangle getSelectedProvinceColorBox() { return selectedProvinceColorBox; }
 }

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -1,6 +1,7 @@
 package com.mapbuilder.mapbuilder.main;
 
 import com.mapbuilder.mapbuilder.ui.POIListPanel;
+import com.mapbuilder.mapbuilder.ui.ProvinceListPanel;
 import javafx.animation.TranslateTransition;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -59,6 +60,11 @@ public class MainView extends AnchorPane {
     private Slider ruinCastleDensitySlider;
     
     private POIListPanel poiListPanel;
+
+    // Province editing
+    private ProvinceListPanel provinceListPanel;
+    private ToggleButton provincePaintToggle;
+    private Slider brushSizeSlider;
 
     public MainView() {
         setupCanvasContainer();
@@ -202,6 +208,37 @@ public class MainView extends AnchorPane {
                 enableKingdomOverlayToggle
         );
         kingdomsTab.setContent(kingdomsContent);
+
+        // ── Province Editing section (added to same kingdoms VBox) ──────────
+        Label provSepLabel = new Label("\u2500\u2500 Province Editing \u2500\u2500");
+        provSepLabel.setStyle("-fx-text-fill: #888888; -fx-font-size: 11px;");
+
+        provincePaintToggle = new ToggleButton("\uD83C\uDFA8  Province Paint Mode");
+        provincePaintToggle.setMaxWidth(Double.MAX_VALUE);
+
+        Label brushSizeLabel = new Label("Brush Size");
+        brushSizeLabel.setStyle("-fx-text-fill: white;");
+        brushSizeSlider = new Slider(1, 15, 3);
+        brushSizeSlider.setShowTickMarks(true);
+        brushSizeSlider.setShowTickLabels(true);
+        brushSizeSlider.setMajorTickUnit(7);
+        brushSizeSlider.setMinorTickCount(6);
+
+        Label provListTitle = new Label("Provinces");
+        provListTitle.setStyle("-fx-text-fill: white; -fx-font-weight: bold;");
+
+        provinceListPanel = new ProvinceListPanel(null);
+        VBox.setVgrow(provinceListPanel, Priority.ALWAYS);
+
+        kingdomsContent.getChildren().addAll(
+                new Separator(),
+                provSepLabel,
+                provincePaintToggle,
+                brushSizeLabel, brushSizeSlider,
+                new Separator(),
+                provListTitle,
+                provinceListPanel
+        );
 
         // Create POIs Tab
         Tab poisTab = new Tab("POIs");
@@ -522,4 +559,8 @@ public class MainView extends AnchorPane {
     public Slider getRuinCastleDensitySlider() { return ruinCastleDensitySlider; }
     
     public POIListPanel getPOIListPanel() { return poiListPanel; }
+
+    public ToggleButton getProvincePaintToggle()    { return provincePaintToggle; }
+    public Slider       getBrushSizeSlider()        { return brushSizeSlider; }
+    public ProvinceListPanel getProvinceListPanel() { return provinceListPanel; }
 }

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -214,6 +214,7 @@ public class MainView extends AnchorPane {
         provSepLabel.setStyle("-fx-text-fill: #888888; -fx-font-size: 11px;");
 
         provincePaintToggle = new ToggleButton("\uD83C\uDFA8  Province Paint Mode");
+        provincePaintToggle.setId("province-paint-toggle");
         provincePaintToggle.setMaxWidth(Double.MAX_VALUE);
 
         Label brushSizeLabel = new Label("Brush Size");

--- a/src/main/java/com/mapbuilder/mapbuilder/ui/ProvinceListPanel.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/ui/ProvinceListPanel.java
@@ -1,0 +1,176 @@
+package com.mapbuilder.mapbuilder.ui;
+
+import com.mapbuilder.mapbuilder.core.map.Kingdom;
+import com.mapbuilder.mapbuilder.main.MainPresenter;
+import javafx.collections.FXCollections;
+import javafx.geometry.Pos;
+import javafx.scene.control.*;
+import javafx.scene.layout.*;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
+
+import java.util.List;
+
+/**
+ * ProvinceListPanel displays all provinces (kingdoms) in a scrollable list.
+ *
+ * <p>Features:
+ * <ul>
+ *   <li>Color swatch + province name per row</li>
+ *   <li>Inline {@link ColorPicker} to change a province's colour</li>
+ *   <li>Single click → selects the province for painting</li>
+ *   <li>Double click → opens a rename dialog</li>
+ * </ul>
+ */
+public class ProvinceListPanel extends VBox {
+
+    private MainPresenter presenter;
+    private ListView<Kingdom> listView;
+
+    /**
+     * @param presenter the {@link MainPresenter} (may be {@code null}; set later via
+     *                  {@link #setPresenter(MainPresenter)})
+     */
+    public ProvinceListPanel(MainPresenter presenter) {
+        super(5);
+        this.presenter = presenter;
+        setStyle("-fx-padding: 5; -fx-border-color: transparent;");
+        setFillWidth(true);
+        initListView();
+    }
+
+    /** Late-initialises the presenter reference (called from {@code MainPresenter.setView()}). */
+    public void setPresenter(MainPresenter presenter) {
+        this.presenter = presenter;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private void initListView() {
+        listView = new ListView<>();
+        listView.setPrefHeight(180);
+        listView.setStyle(
+                "-fx-background-color: #1e1e1e; -fx-control-inner-background: #1e1e1e;");
+
+        listView.setCellFactory(lv -> new ListCell<>() {
+            @Override
+            protected void updateItem(Kingdom k, boolean empty) {
+                super.updateItem(k, empty);
+                setStyle("-fx-background-color: #1e1e1e;");
+                if (empty || k == null) {
+                    setText(null);
+                    setGraphic(null);
+                    return;
+                }
+
+                HBox row = new HBox(8);
+                row.setAlignment(Pos.CENTER_LEFT);
+                row.setStyle("-fx-background-color: #1e1e1e;");
+
+                // Colour swatch – updated whenever the picker fires
+                Rectangle swatch = new Rectangle(14, 14);
+                swatch.setArcWidth(3);
+                swatch.setArcHeight(3);
+                swatch.setFill(argbToFX(k.getColorARGB()));
+
+                // Province name
+                Label nameLabel = new Label(k.getName());
+                nameLabel.setStyle("-fx-text-fill: #e0e0e0;");
+                HBox.setHgrow(nameLabel, Priority.ALWAYS);
+
+                // Compact inline colour picker
+                ColorPicker picker = new ColorPicker(argbToFX(k.getColorARGB()));
+                picker.setPrefSize(60, 24);
+                picker.setOnAction(e -> {
+                    Color c = picker.getValue();
+                    k.setColorARGB(fxToArgb(c));
+                    swatch.setFill(c);
+                    if (presenter != null) presenter.onProvinceColorChanged();
+                });
+
+                row.getChildren().addAll(swatch, nameLabel, picker);
+                setGraphic(row);
+            }
+        });
+
+        // Click handling
+        listView.setOnMouseClicked(event -> {
+            Kingdom selected = listView.getSelectionModel().getSelectedItem();
+            if (selected == null || presenter == null) return;
+
+            // Always inform the presenter of the selection
+            presenter.setSelectedKingdom(selected);
+
+            // Double-click → rename dialog
+            if (event.getClickCount() == 2) {
+                TextInputDialog dlg = new TextInputDialog(selected.getName());
+                dlg.setTitle("Rename Province");
+                dlg.setHeaderText("Enter a new name for this province:");
+                dlg.setContentText("Name:");
+                dlg.getDialogPane().getStylesheets().add(
+                        getClass().getResource("/styles.css").toExternalForm());
+                dlg.showAndWait().ifPresent(name -> {
+                    if (!name.isBlank()) {
+                        selected.setName(name.trim());
+                        listView.refresh();
+                    }
+                });
+            }
+        });
+
+        VBox.setVgrow(listView, Priority.ALWAYS);
+
+        ScrollPane scroll = new ScrollPane(listView);
+        scroll.setFitToWidth(true);
+        scroll.setStyle(
+                "-fx-background: #1e1e1e; -fx-control-inner-background: #1e1e1e; -fx-padding: 0;");
+
+        getChildren().add(scroll);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Public API
+
+    /** Replaces the list contents. Called after every map regeneration. */
+    public void updateProvinceList(List<Kingdom> kingdoms) {
+        if (kingdoms == null || kingdoms.isEmpty()) {
+            listView.setItems(FXCollections.emptyObservableList());
+        } else {
+            listView.setItems(FXCollections.observableArrayList(kingdoms));
+        }
+    }
+
+    /** Highlights {@code kingdom} in the list (e.g. after a map-click selection). */
+    public void selectKingdom(Kingdom kingdom) {
+        if (kingdom == null) {
+            listView.getSelectionModel().clearSelection();
+            return;
+        }
+        listView.getSelectionModel().select(kingdom);
+        listView.scrollTo(kingdom);
+    }
+
+    /** Returns the currently selected kingdom, or {@code null}. */
+    public Kingdom getSelectedKingdom() {
+        return listView.getSelectionModel().getSelectedItem();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Colour helpers
+
+    private static Color argbToFX(int argb) {
+        int a = (argb >> 24) & 0xFF;
+        int r = (argb >> 16) & 0xFF;
+        int g = (argb >>  8) & 0xFF;
+        int b =  argb        & 0xFF;
+        return Color.color(r / 255.0, g / 255.0, b / 255.0, a / 255.0);
+    }
+
+    private static int fxToArgb(Color c) {
+        int a = (int) Math.round(c.getOpacity() * 255);
+        int r = (int) Math.round(c.getRed()     * 255);
+        int g = (int) Math.round(c.getGreen()   * 255);
+        int b = (int) Math.round(c.getBlue()    * 255);
+        return (a << 24) | (r << 16) | (g << 8) | b;
+    }
+}

--- a/src/main/java/com/mapbuilder/mapbuilder/ui/ProvinceListPanel.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/ui/ProvinceListPanel.java
@@ -85,7 +85,10 @@ public class ProvinceListPanel extends VBox {
                     Color c = picker.getValue();
                     k.setColorARGB(fxToArgb(c));
                     swatch.setFill(c);
-                    if (presenter != null) presenter.onProvinceColorChanged();
+                    if (presenter != null) {
+                        presenter.onProvinceColorChanged();
+                        presenter.setSelectedKingdom(k);
+                    }
                 });
 
                 row.getChildren().addAll(swatch, nameLabel, picker);
@@ -113,6 +116,7 @@ public class ProvinceListPanel extends VBox {
                     if (!name.isBlank()) {
                         selected.setName(name.trim());
                         listView.refresh();
+                        presenter.setSelectedKingdom(selected);
                     }
                 });
             }

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -234,3 +234,11 @@
     -fx-background-color: #ffffff;
 }
 
+/* Province Paint Mode toggle — active state */
+.toggle-button:selected {
+    -fx-background-color: #6a3d9a;
+    -fx-text-fill: #ffffff;
+}
+.toggle-button:selected:hover {
+    -fx-background-color: #7a4daa;
+}

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -242,3 +242,19 @@
 .toggle-button:selected:hover {
     -fx-background-color: #7a4daa;
 }
+
+#province-paint-toggle {
+    -fx-background-color: #d35400; /* vibrant orange to stand out */
+    -fx-text-fill: #ffffff;
+    -fx-font-weight: bold;
+}
+#province-paint-toggle:hover {
+    -fx-background-color: #e67e22;
+}
+#province-paint-toggle:selected {
+    -fx-background-color: #27ae60; /* vibrant green when active */
+    -fx-text-fill: #ffffff;
+}
+#province-paint-toggle:selected:hover {
+    -fx-background-color: #2ecc71;
+}

--- a/time-tracking.md
+++ b/time-tracking.md
@@ -30,4 +30,6 @@
 - 21.5.26 - 1 Hour - Implemented basic Map Labels (create, edit, delete, drag-and-drop)
 - 21.5.26 - 1 Hour - Fixed map label rendering issues with the new LOD viewport system
 - 21.5.26 - 30 Minutes - Added confirmation dialog for deletion and reviewed PR #39
-
+- 3.6.26 - 1 Hour - Province List Panel and color picking
+- 3.6.26 - 1 Hour - Province Paint Mode
+- 3.6.26 - 30 Minutes - Province Paint Mode improvements & UI fixes


### PR DESCRIPTION
This pull request introduces an interactive "province painting" feature to the map editor, allowing users to manually edit province (kingdom) assignments on the map using a brush tool. It also adds a province list panel for easy selection and color editing, and updates the data model to support these features. The main changes are grouped below.

**Province Painting & UI Integration:**

* Added province painting mode to `MainPresenter`, including brush-based painting, drag-to-paint, and annexing of enclosed areas. The UI now supports toggling paint mode, selecting a province to paint, and updating province colors live. (`src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java`, [[1]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R63-R68) [[2]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R101-R108) [[3]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R124-R135) [[4]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R153-R157) [[5]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R227-R252) [[6]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R510) [[7]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R966-R1197)

* Integrated province painting controls and the new `ProvinceListPanel` into the main view, including UI elements for brush size, color display, and paint mode toggle. (`src/main/java/com/mapbuilder/mapbuilder/main/MainView.java`, [[1]](diffhunk://#diff-534f9632d0a84879f787167cc5ae1aa58f88d83a53c37c6dee17bdba11b5da4cR57-R71) [[2]](diffhunk://#diff-534f9632d0a84879f787167cc5ae1aa58f88d83a53c37c6dee17bdba11b5da4cL173-R182) [[3]](diffhunk://#diff-534f9632d0a84879f787167cc5ae1aa58f88d83a53c37c6dee17bdba11b5da4cR4)

**Kingdom Data Model Enhancements:**

* Added a `name` property and setter/getter methods to `Kingdom`, with default naming ("Province N"). (`src/main/java/com/mapbuilder/mapbuilder/core/map/Kingdom.java`, [src/main/java/com/mapbuilder/mapbuilder/core/map/Kingdom.javaR7-R21](diffhunk://#diff-ddc48f86606cb86cc697840247342a2d0b048ff5d4205f859018e2aaf5f22d22R7-R21))

* Extended `MapGrid` to store and manage a list of `Kingdom` objects, with new getter and setter methods. (`src/main/java/com/mapbuilder/mapbuilder/core/map/MapGrid.java`, [[1]](diffhunk://#diff-de2c12e5cbb39c2eb619f9f4316784e21a99c458f639b055eeca259e558ea725R11-R18) [[2]](diffhunk://#diff-de2c12e5cbb39c2eb619f9f4316784e21a99c458f639b055eeca259e558ea725R84-R93)

**Generation Pipeline & Synchronization:**

* Updated `KingdomPass` to always set the kingdoms list on `MapGrid`, and to clear province assignments if no kingdoms are generated. (`src/main/java/com/mapbuilder/mapbuilder/core/map/generator/KingdomPass.java`, [[1]](diffhunk://#diff-795c9da76c6bc0c615f30b0b5e9657e628337c0b56de1a580aa11143a9e760f8L32-R38) [[2]](diffhunk://#diff-795c9da76c6bc0c615f30b0b5e9657e628337c0b56de1a580aa11143a9e760f8R126)

**Province List Panel Integration:**

* Connected the new `ProvinceListPanel` to the presenter and view, allowing province selection and color editing from the UI. (`src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java`, [[1]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R80) [[2]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R510); `src/main/java/com/mapbuilder/mapbuilder/main/MainView.java`, [[3]](diffhunk://#diff-534f9632d0a84879f787167cc5ae1aa58f88d83a53c37c6dee17bdba11b5da4cR57-R71)

These changes together enable manual province editing and improve the workflow for managing provinces/kingdoms on the map.