### PR TITLE
Feature/manage pois

### DIFF
--- a/src/main/java/com/mapbuilder/mapbuilder/core/map/PointOfInterest.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/core/map/PointOfInterest.java
@@ -2,21 +2,22 @@ package com.mapbuilder.mapbuilder.core.map;
 
 /**
  * Represents a Point of Interest (POI) on the map.
- * POIs are immutable after construction, except for editable fields:
- * name, description, customColor, and customIcon.
- * 
+ * The identity fields {@code id}, {@code createdAt}, and {@code createdByRule}
+ * are immutable after construction. All other fields are editable to support
+ * manual POI management (rename, retype, move, recolor, re-icon).
+ *
  * This class is designed to be serialization-friendly with no circular references.
  */
 public class PointOfInterest {
-    // Immutable fields (set at construction)
+    // Immutable identity fields (set at construction)
     private final int id;
-    private final int x;
-    private final int y;
-    private final POIType type;
     private final long createdAt;
     private final String createdByRule;
-    
+
     // Editable fields
+    private int x;
+    private int y;
+    private POIType type;
     private String name;
     private String description;
     private Integer customColor;      // ARGB as Integer, nullable
@@ -76,19 +77,41 @@ public class PointOfInterest {
     public int getX() {
         return x;
     }
-    
+
+    /**
+     * Set the X coordinate of this POI on the map. Used when moving a POI.
+     */
+    public void setX(int x) {
+        this.x = x;
+    }
+
     /**
      * Get the Y coordinate of this POI on the map.
      */
     public int getY() {
         return y;
     }
-    
+
+    /**
+     * Set the Y coordinate of this POI on the map. Used when moving a POI.
+     */
+    public void setY(int y) {
+        this.y = y;
+    }
+
     /**
      * Get the POIType of this POI.
      */
     public POIType getType() {
         return type;
+    }
+
+    /**
+     * Set the POIType of this POI. Changing the type updates the default
+     * icon sprite and color used during rendering.
+     */
+    public void setType(POIType type) {
+        this.type = type;
     }
     
     /**

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -8,6 +8,7 @@ import com.mapbuilder.mapbuilder.core.map.MapCell;
 import com.mapbuilder.mapbuilder.core.map.MapGenerator;
 import com.mapbuilder.mapbuilder.core.map.MapGrid;
 import com.mapbuilder.mapbuilder.core.map.PointOfInterest;
+import com.mapbuilder.mapbuilder.core.map.POIType;
 import com.mapbuilder.mapbuilder.ui.POIEditorDialog;
 import com.mapbuilder.mapbuilder.ui.POIIconMapper;
 import com.mapbuilder.mapbuilder.ui.ProvinceListPanel;
@@ -66,6 +67,10 @@ public class MainPresenter {
     private double lastPaintX = -1;
     private double lastPaintY = -1;
 
+    // POI editing
+    private boolean addPoiMode = false;
+    private PointOfInterest draggedPOI = null;
+
     public MainPresenter() {
         this.model = new MainModel();
         this.debounce = new PauseTransition(Duration.millis(300));
@@ -106,12 +111,25 @@ public class MainPresenter {
                 event.consume();
                 return;
             }
+            // Add-POI mode — place a new POI on press
+            if (addPoiMode && event.getButton() == javafx.scene.input.MouseButton.PRIMARY) {
+                placePOIAtScreen(event.getX(), event.getY());
+                event.consume();
+                return;
+            }
             if (event.getButton() == javafx.scene.input.MouseButton.PRIMARY) {
                 double x = event.getX();
                 double y = event.getY();
                 com.mapbuilder.mapbuilder.core.map.MapLabel label = getLabelAt(x, y);
                 if (label != null) {
                     draggedLabel = label;
+                    event.consume();
+                    return;
+                }
+                // Start dragging a POI marker under the cursor
+                PointOfInterest poi = getPOIAt(x, y);
+                if (poi != null) {
+                    draggedPOI = poi;
                     event.consume();
                     return;
                 }
@@ -142,6 +160,20 @@ public class MainPresenter {
                 event.consume();
                 return;
             }
+            if (draggedPOI != null) {
+                MapGrid grid = model.getCurrentGrid();
+                if (grid != null) {
+                    int cx = (int) (viewOffsetX + event.getX() / pixelsPerCell);
+                    int cy = (int) (viewOffsetY + event.getY() / pixelsPerCell);
+                    cx = Math.max(0, Math.min(grid.getWidth() - 1, cx));
+                    cy = Math.max(0, Math.min(grid.getHeight() - 1, cy));
+                    draggedPOI.setX(cx);
+                    draggedPOI.setY(cy);
+                    renderMap();
+                }
+                event.consume();
+                return;
+            }
             double dx = event.getSceneX() - dragStart[0];
             double dy = event.getSceneY() - dragStart[1];
             dragStart[0] = event.getSceneX();
@@ -156,6 +188,7 @@ public class MainPresenter {
                 annexEnclosedAreas();
             }
             draggedLabel = null;
+            draggedPOI = null;
         });
 
         view.getRandomSeedButton().setOnAction(e -> {
@@ -188,6 +221,15 @@ public class MainPresenter {
             double x = event.getX();
             double y = event.getY();
             com.mapbuilder.mapbuilder.core.map.MapLabel clickedLabel = getLabelAt(x, y);
+
+            // Double-click on a POI marker opens its editor (takes priority)
+            if (event.getClickCount() == 2 && !provincePaintMode && !addPoiMode) {
+                PointOfInterest poiHit = getPOIAt(x, y);
+                if (poiHit != null) {
+                    openPOIEditor(poiHit);
+                    return;
+                }
+            }
 
             if (event.getClickCount() == 2 && !provincePaintMode) {
                 if (clickedLabel != null) {
@@ -242,6 +284,21 @@ public class MainPresenter {
             view.getCanvasContainer().setCursor(
                     newV ? javafx.scene.Cursor.CROSSHAIR : javafx.scene.Cursor.DEFAULT);
             if (!newV) setSelectedKingdom(null);
+            // Mutually exclusive with add-POI mode
+            if (newV && view.getAddPoiToggle().isSelected()) {
+                view.getAddPoiToggle().setSelected(false);
+            }
+        });
+
+        // Add-POI mode toggle
+        view.getAddPoiToggle().selectedProperty().addListener((obs, oldV, newV) -> {
+            addPoiMode = newV;
+            view.getCanvasContainer().setCursor(
+                    newV ? javafx.scene.Cursor.CROSSHAIR : javafx.scene.Cursor.DEFAULT);
+            // Mutually exclusive with province paint mode
+            if (newV && view.getProvincePaintToggle().isSelected()) {
+                view.getProvincePaintToggle().setSelected(false);
+            }
         });
 
         // Automatically turn off paint mode when leaving the Kingdoms tab
@@ -264,6 +321,60 @@ public class MainPresenter {
             }
         }
         return null;
+    }
+
+    /**
+     * Returns the POI whose marker is under the given screen position, or null.
+     * Uses the same hover-radius logic as {@link #renderPOIs()}, picking the
+     * closest marker when several overlap.
+     */
+    private PointOfInterest getPOIAt(double screenX, double screenY) {
+        MapGrid grid = model.getCurrentGrid();
+        if (grid == null) return null;
+        List<PointOfInterest> pois = grid.getPointsOfInterest();
+        if (pois == null) return null;
+
+        double hoverRadius = Math.max(12, Math.min(28, 20 * pixelsPerCell));
+        PointOfInterest hit = null;
+        double bestDist = Double.MAX_VALUE;
+        for (PointOfInterest poi : pois) {
+            double sx = (poi.getX() - viewOffsetX) * pixelsPerCell;
+            double sy = (poi.getY() - viewOffsetY) * pixelsPerCell;
+            double dist = Math.hypot(screenX - sx, screenY - sy);
+            if (dist < hoverRadius && dist < bestDist) {
+                bestDist = dist;
+                hit = poi;
+            }
+        }
+        return hit;
+    }
+
+    /**
+     * Places a new user POI at the cell under the given screen position, adds it
+     * to the map, and opens the editor for naming/typing. Add-POI mode is turned
+     * off after a single placement to avoid repeated modal dialogs.
+     */
+    private void placePOIAtScreen(double screenX, double screenY) {
+        MapGrid grid = model.getCurrentGrid();
+        if (grid == null) return;
+
+        int cx = (int) (viewOffsetX + screenX / pixelsPerCell);
+        int cy = (int) (viewOffsetY + screenY / pixelsPerCell);
+        cx = Math.max(0, Math.min(grid.getWidth() - 1, cx));
+        cy = Math.max(0, Math.min(grid.getHeight() - 1, cy));
+
+        int nextId = 0;
+        for (PointOfInterest poi : grid.getPointsOfInterest()) {
+            if (poi.getId() >= nextId) nextId = poi.getId() + 1;
+        }
+
+        PointOfInterest created = new PointOfInterest(
+                nextId, cx, cy, POIType.CITY, "New POI", "user_placed");
+        grid.addPointOfInterest(created);
+        renderMap();
+
+        view.getAddPoiToggle().setSelected(false);
+        openPOIEditor(created);
     }
 
     private void applyDarkTheme(javafx.scene.control.Dialog<?> dialog) {

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -63,6 +63,7 @@ public class MainView extends AnchorPane {
     private Slider ruinCastleDensitySlider;
     
     private POIListPanel poiListPanel;
+    private ToggleButton addPoiToggle;
 
     // Province editing
     private ProvinceListPanel provinceListPanel;
@@ -284,12 +285,17 @@ public class MainView extends AnchorPane {
         ruinCastleDensitySlider.setMinorTickCount(4);
         ruinCastleDensitySlider.setSnapToTicks(true);
 
+        addPoiToggle = new ToggleButton("➕  POI hinzufügen");
+        addPoiToggle.setId("add-poi-toggle");
+        addPoiToggle.setMaxWidth(Double.MAX_VALUE);
+
         poisContent.getChildren().addAll(
                 new Label("Dungeon Density"), dungeonDensitySlider,
                 new Label("Settlement Density"), settlementDensitySlider,
                 new Label("Ruin & Castle Density"), ruinCastleDensitySlider,
                 new Separator(),
-                new Label("Points of Interest")
+                new Label("Points of Interest"),
+                addPoiToggle
         );
 
         // Add POI List Panel to POIs tab
@@ -626,6 +632,7 @@ public class MainView extends AnchorPane {
     public Slider getRuinCastleDensitySlider() { return ruinCastleDensitySlider; }
     
     public POIListPanel getPOIListPanel() { return poiListPanel; }
+    public ToggleButton getAddPoiToggle() { return addPoiToggle; }
 
     public ToggleButton getProvincePaintToggle()    { return provincePaintToggle; }
     public Tab getKingdomsTab()                     { return kingdomsTab; }

--- a/src/main/java/com/mapbuilder/mapbuilder/ui/POIEditorDialog.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/ui/POIEditorDialog.java
@@ -149,6 +149,7 @@ public class POIEditorDialog extends Dialog<PointOfInterest> {
         saveBtn.setOnAction(e -> {
             // Update POI with field values
             poi.setName(nameField.getText());
+            poi.setType(typeCombo.getValue());
             poi.setDescription(descriptionArea.getText());
             poi.setCustomColor(colorToARGB(colorPicker.getValue()));
             poi.setCustomIcon(iconCombo.getValue());

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -258,3 +258,15 @@
 #province-paint-toggle:selected:hover {
     -fx-background-color: #2ecc71;
 }
+
+#add-poi-toggle {
+    -fx-text-fill: black;
+    -fx-font-weight: bold;
+}
+#add-poi-toggle:selected {
+    -fx-background-color: #58d68d; /* light green so black text stays readable */
+    -fx-text-fill: black;
+}
+#add-poi-toggle:selected:hover {
+    -fx-background-color: #6fe09e;
+}

--- a/src/test/java/com/mapbuilder/mapbuilder/core/map/PointOfInterestTest.java
+++ b/src/test/java/com/mapbuilder/mapbuilder/core/map/PointOfInterestTest.java
@@ -56,17 +56,22 @@ class PointOfInterestTest {
     }
 
     @Test
-    void testPointOfInterestImmutableFields() {
+    void testPointOfInterestPositionAndTypeSetters() {
         PointOfInterest poi = new PointOfInterest(4, 30, 40, POIType.RUIN, "Ancient Ruin", "border_dungeon");
-        int originalX = poi.getX();
-        int originalY = poi.getY();
-        POIType originalType = poi.getType();
-        
-        // Verify we can't change immutable fields by trying to create similar POI with different values
-        PointOfInterest poi2 = new PointOfInterest(4, 31, 41, POIType.DUNGEON, "Ancient Ruin", "border_dungeon");
-        assertNotEquals(originalX, poi2.getX(), "Different POI should have different X");
-        assertNotEquals(originalY, poi2.getY(), "Different POI should have different Y");
-        assertNotEquals(originalType, poi2.getType(), "Different POI should have different type");
+
+        // Moving a POI updates its coordinates
+        poi.setX(31);
+        poi.setY(41);
+        assertEquals(31, poi.getX(), "setX should update the X coordinate");
+        assertEquals(41, poi.getY(), "setY should update the Y coordinate");
+
+        // Retyping a POI updates its type
+        poi.setType(POIType.DUNGEON);
+        assertEquals(POIType.DUNGEON, poi.getType(), "setType should update the type");
+
+        // Identity fields remain unchanged
+        assertEquals(4, poi.getId(), "ID must stay constant");
+        assertEquals("border_dungeon", poi.getCreatedByRule(), "createdByRule must stay constant");
     }
 
     @Test

--- a/time-tracking.md
+++ b/time-tracking.md
@@ -32,6 +32,7 @@
 - 28.4.26 - 2 Hours - LOD
 - 29.4.26 - 2 Hours - LOD improvements & fixes
 - 4.5.26 - 2 Hours - LOD last fixes and Map Gen Fix
+- 11.6.26 - 1.5 Hours - manage POIs 
 
 # Ali
 


### PR DESCRIPTION
This pull request introduces a comprehensive set of improvements for managing Points of Interest (POIs) on the map. The main enhancements include making POI fields for position and type editable, adding a new UI toggle and workflow for user-placed POIs, and enabling direct manipulation (move, edit, retype) of POIs from the map interface. The changes also ensure the UI is intuitive, with mutually exclusive editing modes and appropriate styling.

**POI Editability and Model Changes**
- Made `x`, `y`, and `type` fields of `PointOfInterest` editable, with new setters and updated documentation to clarify which fields are mutable and which are immutable. (`src/main/java/com/mapbuilder/mapbuilder/core/map/PointOfInterest.java`) [[1]](diffhunk://#diff-58b574c6437a8934b2d4b3779ac51cf77e41b2ef90c0ffd4f2cb3390031c3395L5-R20) [[2]](diffhunk://#diff-58b574c6437a8934b2d4b3779ac51cf77e41b2ef90c0ffd4f2cb3390031c3395R81-R116)
- Updated and expanded unit tests to verify that POI position and type can be changed after creation, while identity fields remain immutable. (`src/test/java/com/mapbuilder/mapbuilder/core/map/PointOfInterestTest.java`)

**User Interaction and UI Enhancements**
- Added an "Add POI" toggle button to the POI panel, with new event handlers in `MainPresenter` to support add-POI mode and mutually exclusive editing modes with province paint. (`src/main/java/com/mapbuilder/mapbuilder/main/MainView.java`, `src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java`) [[1]](diffhunk://#diff-534f9632d0a84879f787167cc5ae1aa58f88d83a53c37c6dee17bdba11b5da4cR66) [[2]](diffhunk://#diff-534f9632d0a84879f787167cc5ae1aa58f88d83a53c37c6dee17bdba11b5da4cR288-R298) [[3]](diffhunk://#diff-534f9632d0a84879f787167cc5ae1aa58f88d83a53c37c6dee17bdba11b5da4cR635) [[4]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R70-R73) [[5]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R287-R301)
- Implemented logic to allow users to place new POIs on the map, move existing POIs by dragging, and open the POI editor with a double-click. (`src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java`) [[1]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R114-R119) [[2]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R129-R135) [[3]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R163-R176) [[4]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R191) [[5]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R225-R233) [[6]](diffhunk://#diff-6d2181e419f3a3ac8bdf3078be351a88cbb6fee78d856844bdb1b4c8bb52cda2R326-R379)
- Updated the POI editor dialog to allow changing the POI type. (`src/main/java/com/mapbuilder/mapbuilder/ui/POIEditorDialog.java`)

**Styling and Usability**
- Added custom styles for the new "Add POI" toggle to ensure clear visual feedback and accessibility. (`src/main/resources/styles.css`)

**Other**
- Updated the time tracking log to reflect work on POI management. (`time-tracking.md`)