### PR TITLE
fix/layer-toggles

### DIFF
--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -224,6 +224,7 @@ public class MainPresenter {
         view.getEnableKingdomOverlayToggle().selectedProperty().addListener((obs, oldV, newV) -> regenerateImages());
         view.getRiversLakesLayerToggle().selectedProperty().addListener((obs, oldV, newV) -> regenerateImages());
         view.getLabelsLayerToggle().selectedProperty().addListener((obs, oldV, newV) -> renderMap());
+        view.getGridLayerToggle().selectedProperty().addListener((obs, oldV, newV) -> renderMap());
 
         view.getCanvasContainer().setOnMouseClicked(event -> {
             double x = event.getX();
@@ -649,7 +650,39 @@ public class MainPresenter {
             // Draw hardware-accelerated image properly cropped
             gc.drawImage(activeImage, intersectX, intersectY, intersectW, intersectH, destX, destY, destW, destH);
         }
-        
+
+        // ── Grid overlay ──────────────────────────────────────────────────
+        if (view.getGridLayerToggle().isSelected()) {
+            gc.setStroke(javafx.scene.paint.Color.color(1, 1, 1, 0.15));
+            gc.setLineWidth(0.5);
+            int gridW = baseGrid.getWidth();
+            int gridH = baseGrid.getHeight();
+            // Map bounding box in screen coordinates
+            double mapScreenX0 = (0 - viewOffsetX) * pixelsPerCell;
+            double mapScreenY0 = (0 - viewOffsetY) * pixelsPerCell;
+            double mapScreenX1 = (gridW - viewOffsetX) * pixelsPerCell;
+            double mapScreenY1 = (gridH - viewOffsetY) * pixelsPerCell;
+            // Clamp to canvas
+            double clipTop    = Math.max(0, mapScreenY0);
+            double clipBottom  = Math.min(canvasH, mapScreenY1);
+            double clipLeft   = Math.max(0, mapScreenX0);
+            double clipRight  = Math.min(canvasW, mapScreenX1);
+            // Vertical lines
+            int startCellX = Math.max(0, (int) viewOffsetX);
+            int endCellX = Math.min(gridW, (int) (viewOffsetX + canvasW / pixelsPerCell) + 1);
+            for (int cx = startCellX; cx <= endCellX; cx++) {
+                double sx = (cx - viewOffsetX) * pixelsPerCell;
+                gc.strokeLine(sx, clipTop, sx, clipBottom);
+            }
+            // Horizontal lines
+            int startCellY = Math.max(0, (int) viewOffsetY);
+            int endCellY = Math.min(gridH, (int) (viewOffsetY + canvasH / pixelsPerCell) + 1);
+            for (int cy = startCellY; cy <= endCellY; cy++) {
+                double sy = (cy - viewOffsetY) * pixelsPerCell;
+                gc.strokeLine(clipLeft, sy, clipRight, sy);
+            }
+        }
+
         renderPOIs();
         renderLabels();
         view.getPOIListPanel().updatePOIList(baseGrid.getPointsOfInterest());
@@ -1270,7 +1303,8 @@ public class MainPresenter {
         PixelWriter writer = baseMapImage.getPixelWriter();
         for (int cy = minY; cy <= maxY; cy++) {
             for (int cx = minX; cx <= maxX; cx++) {
-                writer.setArgb(cx, cy, getColorAt(cx, cy, grid, showBorders, showOverlay));
+                writer.setArgb(cx, cy, getColorAt(cx, cy, grid, showBorders, showOverlay,
+                        view.getRiversLakesLayerToggle().isSelected()));
             }
         }
         // Invalidate LOD cache so zoomed-out views get the new pixels too

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -338,6 +338,9 @@ public class MainPresenter {
      * closest marker when several overlap.
      */
     private PointOfInterest getPOIAt(double screenX, double screenY) {
+        if (view.getPoiToggle() != null && !view.getPoiToggle().isSelected()) {
+            return null;
+        }
         MapGrid grid = model.getCurrentGrid();
         if (grid == null) return null;
         List<PointOfInterest> pois = grid.getPointsOfInterest();

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -222,6 +222,7 @@ public class MainPresenter {
         
         view.getEnableBordersToggle().selectedProperty().addListener((obs, oldV, newV) -> regenerateImages());
         view.getEnableKingdomOverlayToggle().selectedProperty().addListener((obs, oldV, newV) -> regenerateImages());
+        view.getRiversLakesLayerToggle().selectedProperty().addListener((obs, oldV, newV) -> regenerateImages());
         view.getLabelsLayerToggle().selectedProperty().addListener((obs, oldV, newV) -> renderMap());
 
         view.getCanvasContainer().setOnMouseClicked(event -> {
@@ -431,7 +432,8 @@ public class MainPresenter {
         boolean showBorders = view.getEnableBordersToggle().isSelected();
         boolean showOverlay = view.getEnableKingdomOverlayToggle().isSelected();
         
-        baseMapImage = createImageFromGrid(baseGrid, showBorders, showOverlay);
+        baseMapImage = createImageFromGrid(baseGrid, showBorders, showOverlay,
+                view.getRiversLakesLayerToggle().isSelected());
         lodImageCache.clear();
         
         renderMap();
@@ -544,7 +546,8 @@ public class MainPresenter {
             if (grid != null) {
                 boolean showBorders = view.getEnableBordersToggle().isSelected();
                 boolean showOverlay = view.getEnableKingdomOverlayToggle().isSelected();
-                baseMapImage = createImageFromGrid(grid, showBorders, showOverlay);
+                baseMapImage = createImageFromGrid(grid, showBorders, showOverlay,
+                        view.getRiversLakesLayerToggle().isSelected());
             }
             
             renderMap();
@@ -816,7 +819,8 @@ public class MainPresenter {
             
             boolean showBorders = view.getEnableBordersToggle().isSelected();
             boolean showOverlay = view.getEnableKingdomOverlayToggle().isSelected();
-            lodImageCache.put(region.cacheKey(), createImageFromGrid(lodGrid, showBorders, showOverlay));
+            lodImageCache.put(region.cacheKey(), createImageFromGrid(lodGrid, showBorders, showOverlay,
+                    view.getRiversLakesLayerToggle().isSelected()));
             
             activeLodLevel = region.lod;
             renderMap(); // re-render with the freshly cached LOD grid
@@ -873,10 +877,11 @@ public class MainPresenter {
         }
     }
 
-    private WritableImage createImageFromGrid(MapGrid grid, boolean showBorders, boolean showOverlay) {
+    private WritableImage createImageFromGrid(MapGrid grid, boolean showBorders, boolean showOverlay,
+                                               boolean showRiversLakes) {
         int w = grid.getWidth();
         int h = grid.getHeight();
-        int[] pixels = buildColorCache(grid, w, h, showBorders, showOverlay);
+        int[] pixels = buildColorCache(grid, w, h, showBorders, showOverlay, showRiversLakes);
         WritableImage image = new WritableImage(w, h);
         image.getPixelWriter().setPixels(0, 0, w, h, PixelFormat.getIntArgbPreInstance(), pixels, 0, w);
         return image;
@@ -884,26 +889,30 @@ public class MainPresenter {
 
     /** Pre-computes one ARGB color per grid cell into a flat array [y*gW+x]. */
     private int[] buildColorCache(MapGrid grid, int gW, int gH,
-                                  boolean showBorders, boolean showOverlay) {
+                                  boolean showBorders, boolean showOverlay,
+                                  boolean showRiversLakes) {
         int[] cache = new int[gW * gH];
         for (int cy = 0; cy < gH; cy++) {
             for (int cx = 0; cx < gW; cx++) {
-                cache[cy * gW + cx] = getColorAt(cx, cy, grid, showBorders, showOverlay);
+                cache[cy * gW + cx] = getColorAt(cx, cy, grid, showBorders, showOverlay, showRiversLakes);
             }
         }
         return cache;
     }
 
-    private int getColorAt(int cx, int cy, MapGrid grid, boolean showBorders, boolean showOverlay) {
+    private int getColorAt(int cx, int cy, MapGrid grid, boolean showBorders, boolean showOverlay,
+                            boolean showRiversLakes) {
         if (cx < 0 || cx >= grid.getWidth() || cy < 0 || cy >= grid.getHeight()) {
             return 0xFF00008B;
         }
         MapCell cell = grid.getCell(cx, cy);
         int color = cell.getMixedColorARGB();
-        if (cell.isLake()) {
-            color = COLOR_LAKE;
-        } else if (cell.isRiver()) {
-            color = COLOR_RIVER;
+        if (showRiversLakes) {
+            if (cell.isLake()) {
+                color = COLOR_LAKE;
+            } else if (cell.isRiver()) {
+                color = COLOR_RIVER;
+            }
         }
         if (cell.getKingdom() != null) {
             if (showOverlay) {

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -306,6 +306,7 @@ public class MainPresenter {
             if (newV && view.getAddPoiToggle().isSelected()) {
                 view.getAddPoiToggle().setSelected(false);
             }
+            updateProvincePaintButtonText();
         });
 
         // Add-POI mode toggle
@@ -1205,6 +1206,19 @@ public class MainPresenter {
         } else {
             view.getSelectedProvinceLabel().setText("None");
             view.getSelectedProvinceColorBox().setFill(javafx.scene.paint.Color.TRANSPARENT);
+        }
+        updateProvincePaintButtonText();
+    }
+
+    private void updateProvincePaintButtonText() {
+        if (provincePaintMode) {
+            if (selectedPaintKingdom == null) {
+                view.getProvincePaintToggle().setText("\uD83C\uDFA8  Select from provinces list!");
+            } else {
+                view.getProvincePaintToggle().setText("\uD83C\uDFA8  Start painting on map!");
+            }
+        } else {
+            view.getProvincePaintToggle().setText("\uD83C\uDFA8  Province Paint Mode");
         }
     }
 

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -26,6 +26,7 @@ import javafx.util.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Stack;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.IntStream;
 import javafx.scene.image.WritableImage;
@@ -66,8 +67,8 @@ public class MainPresenter {
     private Kingdom selectedPaintKingdom = null;
     private double lastPaintX = -1;
     private double lastPaintY = -1;
-    private final java.util.Stack<java.util.Map<com.mapbuilder.mapbuilder.core.map.MapCell, Kingdom>> paintUndoStack = new java.util.Stack<>();
-    private java.util.Map<com.mapbuilder.mapbuilder.core.map.MapCell, Kingdom> currentStrokeChanges = null;
+    private final Stack<Map<MapCell, Kingdom>> paintUndoStack = new Stack<>();
+    private Map<MapCell, Kingdom> currentStrokeChanges = null;
 
     // POI editing
     private boolean addPoiMode = false;
@@ -112,7 +113,7 @@ public class MainPresenter {
                     event.consume();
                     return;
                 }
-                currentStrokeChanges = new java.util.HashMap<>();
+                currentStrokeChanges = new HashMap<>();
                 lastPaintX = event.getX();
                 lastPaintY = event.getY();
                 paintCellsAtScreen(event.getX(), event.getY());
@@ -1443,7 +1444,7 @@ public class MainPresenter {
 
     private void undoLastPaintStroke() {
         if (paintUndoStack.isEmpty()) return;
-        java.util.Map<com.mapbuilder.mapbuilder.core.map.MapCell, Kingdom> stroke = paintUndoStack.pop();
+        Map<MapCell, Kingdom> stroke = paintUndoStack.pop();
         if (stroke.isEmpty()) return;
 
         int minX = Integer.MAX_VALUE;
@@ -1451,8 +1452,8 @@ public class MainPresenter {
         int maxX = Integer.MIN_VALUE;
         int maxY = Integer.MIN_VALUE;
 
-        for (java.util.Map.Entry<com.mapbuilder.mapbuilder.core.map.MapCell, Kingdom> entry : stroke.entrySet()) {
-            com.mapbuilder.mapbuilder.core.map.MapCell cell = entry.getKey();
+        for (Map.Entry<MapCell, Kingdom> entry : stroke.entrySet()) {
+            MapCell cell = entry.getKey();
             Kingdom oldKingdom = entry.getValue();
             cell.setKingdom(oldKingdom);
             

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -222,6 +222,7 @@ public class MainPresenter {
         
         view.getEnableBordersToggle().selectedProperty().addListener((obs, oldV, newV) -> regenerateImages());
         view.getEnableKingdomOverlayToggle().selectedProperty().addListener((obs, oldV, newV) -> regenerateImages());
+        view.getLabelsLayerToggle().selectedProperty().addListener((obs, oldV, newV) -> renderMap());
 
         view.getCanvasContainer().setOnMouseClicked(event -> {
             double x = event.getX();
@@ -653,6 +654,13 @@ public class MainPresenter {
     }
 
     private void renderLabels() {
+        // Skip rendering if labels layer is toggled off
+        if (!view.getLabelsLayerToggle().isSelected()) {
+            javafx.scene.Group canvasGroup = view.getCanvasGroup();
+            canvasGroup.getChildren().removeIf(node -> node instanceof javafx.scene.text.Text);
+            return;
+        }
+
         javafx.scene.Group canvasGroup = view.getCanvasGroup();
         java.util.List<com.mapbuilder.mapbuilder.core.map.MapLabel> labels = model.getLabels();
 

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -66,6 +66,8 @@ public class MainPresenter {
     private Kingdom selectedPaintKingdom = null;
     private double lastPaintX = -1;
     private double lastPaintY = -1;
+    private final java.util.Stack<java.util.Map<com.mapbuilder.mapbuilder.core.map.MapCell, Kingdom>> paintUndoStack = new java.util.Stack<>();
+    private java.util.Map<com.mapbuilder.mapbuilder.core.map.MapCell, Kingdom> currentStrokeChanges = null;
 
     // POI editing
     private boolean addPoiMode = false;
@@ -110,6 +112,7 @@ public class MainPresenter {
                     event.consume();
                     return;
                 }
+                currentStrokeChanges = new java.util.HashMap<>();
                 lastPaintX = event.getX();
                 lastPaintY = event.getY();
                 paintCellsAtScreen(event.getX(), event.getY());
@@ -191,6 +194,12 @@ public class MainPresenter {
                 lastPaintX = -1;
                 lastPaintY = -1;
                 annexEnclosedAreas();
+                if (currentStrokeChanges != null) {
+                    if (!currentStrokeChanges.isEmpty()) {
+                        paintUndoStack.push(currentStrokeChanges);
+                    }
+                    currentStrokeChanges = null;
+                }
             }
             draggedLabel = null;
             draggedPOI = null;
@@ -314,6 +323,17 @@ public class MainPresenter {
         view.getKingdomsTab().selectedProperty().addListener((obs, oldV, newV) -> {
             if (!newV) {
                 view.getProvincePaintToggle().setSelected(false);
+            }
+        });
+
+        view.sceneProperty().addListener((obs, oldScene, newScene) -> {
+            if (newScene != null) {
+                newScene.setOnKeyPressed(event -> {
+                    if (event.isControlDown() && event.getCode() == javafx.scene.input.KeyCode.Z) {
+                        undoLastPaintStroke();
+                        event.consume();
+                    }
+                });
             }
         });
     }
@@ -537,6 +557,8 @@ public class MainPresenter {
         };
 
         task.setOnSucceeded(e -> {
+            paintUndoStack.clear();
+            currentStrokeChanges = null;
             // Invalidate all cached LOD grids — they belong to the old map
             Task<MapGrid> oldLod = runningLodTask;
             if (oldLod != null) oldLod.cancel(false);
@@ -1225,6 +1247,9 @@ public class MainPresenter {
                     MapCell cell = grid.getCell(cx + dx, cy + dy);
                     if (cell != null && cell.getElevation() > waterLevel) {
                         if (cell.getKingdom() != selectedPaintKingdom) {
+                            if (currentStrokeChanges != null && !currentStrokeChanges.containsKey(cell)) {
+                                currentStrokeChanges.put(cell, cell.getKingdom());
+                            }
                             cell.setKingdom(selectedPaintKingdom);
                             minX = Math.min(minX, cx + dx);
                             minY = Math.min(minY, cy + dy);
@@ -1273,6 +1298,9 @@ public class MainPresenter {
                         MapCell cell = grid.getCell(cx + dx, cy + dy);
                         if (cell != null && cell.getElevation() > waterLevel) {
                             if (cell.getKingdom() != selectedPaintKingdom) {
+                                if (currentStrokeChanges != null && !currentStrokeChanges.containsKey(cell)) {
+                                    currentStrokeChanges.put(cell, cell.getKingdom());
+                                }
                                 cell.setKingdom(selectedPaintKingdom);
                                 minX = Math.min(minX, cx + dx);
                                 minY = Math.min(minY, cy + dy);
@@ -1375,6 +1403,9 @@ public class MainPresenter {
                 if (!reachesEdge[x][y]) {
                     MapCell cell = grid.getCell(x, y);
                     if (cell.getKingdom() != selectedPaintKingdom && cell.getElevation() > waterLevel) {
+                        if (currentStrokeChanges != null && !currentStrokeChanges.containsKey(cell)) {
+                            currentStrokeChanges.put(cell, cell.getKingdom());
+                        }
                         cell.setKingdom(selectedPaintKingdom);
                         minX = Math.min(minX, x);
                         minY = Math.min(minY, y);
@@ -1389,5 +1420,29 @@ public class MainPresenter {
         if (changed) {
             updateImagePixels(minX, minY, maxX, maxY);
         }
+    }
+
+    private void undoLastPaintStroke() {
+        if (paintUndoStack.isEmpty()) return;
+        java.util.Map<com.mapbuilder.mapbuilder.core.map.MapCell, Kingdom> stroke = paintUndoStack.pop();
+        if (stroke.isEmpty()) return;
+
+        int minX = Integer.MAX_VALUE;
+        int minY = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE;
+        int maxY = Integer.MIN_VALUE;
+
+        for (java.util.Map.Entry<com.mapbuilder.mapbuilder.core.map.MapCell, Kingdom> entry : stroke.entrySet()) {
+            com.mapbuilder.mapbuilder.core.map.MapCell cell = entry.getKey();
+            Kingdom oldKingdom = entry.getValue();
+            cell.setKingdom(oldKingdom);
+            
+            minX = Math.min(minX, cell.getX());
+            minY = Math.min(minY, cell.getY());
+            maxX = Math.max(maxX, cell.getX());
+            maxY = Math.max(maxY, cell.getY());
+        }
+
+        updateImagePixels(minX, minY, maxX, maxY);
     }
 }

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -1214,11 +1214,16 @@ public class MainPresenter {
         if (provincePaintMode) {
             if (selectedPaintKingdom == null) {
                 view.getProvincePaintToggle().setText("\uD83C\uDFA8  Select from provinces list!");
+                if (!view.getProvincePaintToggle().getStyleClass().contains("no-target")) {
+                    view.getProvincePaintToggle().getStyleClass().add("no-target");
+                }
             } else {
                 view.getProvincePaintToggle().setText("\uD83C\uDFA8  Start painting on map!");
+                view.getProvincePaintToggle().getStyleClass().remove("no-target");
             }
         } else {
             view.getProvincePaintToggle().setText("\uD83C\uDFA8  Province Paint Mode");
+            view.getProvincePaintToggle().getStyleClass().remove("no-target");
         }
     }
 

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -70,6 +70,7 @@ public class MainView extends AnchorPane {
     private ToggleButton enableBordersToggle;
     private ToggleButton enableKingdomOverlayToggle;
     private ToggleButton poiToggle;
+    private ToggleButton labelsLayerToggle;
     private Tab kingdomsTab;
     
     private Slider dungeonDensitySlider;
@@ -564,6 +565,9 @@ public class MainView extends AnchorPane {
             if (i == 1) {
                 poiToggle = toggle;
             }
+            if (i == 0) {
+                labelsLayerToggle = toggle;
+            }
 
             row.getChildren().addAll(nameLabel, rowSpacer, toggle);
             layersPanel.getChildren().add(row);
@@ -681,6 +685,8 @@ public class MainView extends AnchorPane {
     public ProvinceListPanel getProvinceListPanel() { return provinceListPanel; }
     public Label getSelectedProvinceLabel()         { return selectedProvinceLabel; }
     public javafx.scene.shape.Rectangle getSelectedProvinceColorBox() { return selectedProvinceColorBox; }
+
+    public ToggleButton getLabelsLayerToggle() { return labelsLayerToggle; }
 
     private Image loadIcon(String resourcePath) {
         java.io.InputStream stream = getClass().getResourceAsStream(resourcePath);

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -72,6 +72,7 @@ public class MainView extends AnchorPane {
     private ToggleButton poiToggle;
     private ToggleButton labelsLayerToggle;
     private ToggleButton riversLakesLayerToggle;
+    private ToggleButton gridLayerToggle;
     private Tab kingdomsTab;
     
     private Slider dungeonDensitySlider;
@@ -531,7 +532,8 @@ public class MainView extends AnchorPane {
 
         layersPanel.getChildren().add(layersHeaderBox);
 
-        String[] layerNames = {"Labels", "Points of Interest", "Structures & Roads", "Mountains", "Rivers & Lakes", "Grid"};
+        String[] layerNames = {"Labels", "Points of Interest", "Rivers & Lakes", "Grid"};
+        boolean[] layerDefaults = {true, true, true, false};
 
         for (int i = 0; i < layerNames.length; i++) {
             HBox row = new HBox();
@@ -544,13 +546,14 @@ public class MainView extends AnchorPane {
             Pane rowSpacer = new Pane();
             HBox.setHgrow(rowSpacer, Priority.ALWAYS);
 
-            Label iconLabel = new Label("\uf06e");
+            boolean defaultOn = layerDefaults[i];
+            Label iconLabel = new Label(defaultOn ? "\uf06e" : "\uf070");
             iconLabel.setFont(Font.font("FontAwesome", 16));
-            iconLabel.setStyle("-fx-text-fill: #cccccc;");
+            iconLabel.setStyle(defaultOn ? "-fx-text-fill: #cccccc;" : "-fx-text-fill: #777777;");
 
             ToggleButton toggle = new ToggleButton("", iconLabel);
             toggle.setStyle("-fx-background-color: transparent; -fx-cursor: hand; -fx-padding: 2 4;");
-            toggle.setSelected(true);  // All layers visible by default
+            toggle.setSelected(defaultOn);
             int finalI = i;
             toggle.selectedProperty().addListener((obs, oldV, newV) -> {
                 iconLabel.setText(newV ? "\uf06e" : "\uf070");
@@ -562,15 +565,12 @@ public class MainView extends AnchorPane {
                 }
             });
 
-            // Store reference to POI toggle
-            if (i == 1) {
-                poiToggle = toggle;
-            }
-            if (i == 0) {
-                labelsLayerToggle = toggle;
-            }
-            if (i == 4) {
-                riversLakesLayerToggle = toggle;
+            // Store toggle references
+            switch (i) {
+                case 0: labelsLayerToggle = toggle; break;
+                case 1: poiToggle = toggle; break;
+                case 2: riversLakesLayerToggle = toggle; break;
+                case 3: gridLayerToggle = toggle; break;
             }
 
             row.getChildren().addAll(nameLabel, rowSpacer, toggle);
@@ -692,6 +692,7 @@ public class MainView extends AnchorPane {
 
     public ToggleButton getLabelsLayerToggle() { return labelsLayerToggle; }
     public ToggleButton getRiversLakesLayerToggle() { return riversLakesLayerToggle; }
+    public ToggleButton getGridLayerToggle()        { return gridLayerToggle; }
 
     private Image loadIcon(String resourcePath) {
         java.io.InputStream stream = getClass().getResourceAsStream(resourcePath);

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -246,6 +246,9 @@ public class MainView extends AnchorPane {
         brushSizeSlider.setMajorTickUnit(7);
         brushSizeSlider.setMinorTickCount(6);
 
+        Label undoTipLabel = new Label("\uD83D\uDCA1 Tip: Press Ctrl+Z to undo last stroke");
+        undoTipLabel.setStyle("-fx-text-fill: #888888; -fx-font-size: 11px; -fx-font-style: italic;");
+
         Label provListTitle = new Label("Provinces");
         provListTitle.setStyle("-fx-text-fill: white; -fx-font-weight: bold;");
 
@@ -257,6 +260,7 @@ public class MainView extends AnchorPane {
                 provincePaintToggle,
                 selectedProvinceBox,
                 brushSizeLabel, brushSizeSlider,
+                undoTipLabel,
                 new Separator(),
                 provListTitle,
                 provinceListPanel

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -326,7 +326,7 @@ public class MainView extends AnchorPane {
 
         Label seedLabel = new Label("Seed");
         seedLabel.setStyle("-fx-text-fill: white;");
-        seedField = new TextField("12345");
+        seedField = new TextField("12345678");
         seedField.setPrefWidth(100);
         randomSeedButton = new Button("Random Seed");
         randomSeedButton.setStyle("-fx-cursor: hand;");

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -151,7 +151,8 @@ public class MainView extends AnchorPane {
         headerBox.setAlignment(Pos.CENTER_LEFT);
         Label headerLabel = new Label("Generator Settings");
         headerLabel.setStyle("-fx-font-weight: bold; -fx-text-fill: white; -fx-font-size: 16px;");
-        Button collapseLeftBtn = new Button("\u25C0"); // ◀
+        Button collapseLeftBtn = new Button("\uf0d9"); // ◀
+        collapseLeftBtn.setFont(Font.font("FontAwesome", 14));
         collapseLeftBtn.setStyle("-fx-background-color: transparent; -fx-cursor: hand; -fx-text-fill: white;");
         Pane spacer = new Pane();
         HBox.setHgrow(spacer, Priority.ALWAYS);
@@ -426,7 +427,8 @@ public class MainView extends AnchorPane {
     }
 
     private Button setupLeftPanelShowButton(ScrollPane leftScroll) {
-        Button showLeftBtn = new Button("\u25B6"); // ▶
+        Button showLeftBtn = new Button("\uf0da"); // ▶
+        showLeftBtn.setFont(Font.font("FontAwesome", 14));
         showLeftBtn.setStyle("-fx-background-color: #2b2b2b; -fx-text-fill: white; -fx-background-radius: 0 8 8 0; -fx-padding: 10 5; -fx-cursor: hand;");
         showLeftBtn.setVisible(false);
         AnchorPane.setTopAnchor(showLeftBtn, 0.0);
@@ -528,7 +530,8 @@ public class MainView extends AnchorPane {
         layersHeaderBox.setAlignment(Pos.CENTER_LEFT);
         Label layersHeaderLabel = new Label("Layers");
         layersHeaderLabel.setStyle("-fx-font-weight: bold; -fx-text-fill: white; -fx-font-size: 16px;");
-        Button collapseRightBtn = new Button("\u25B6"); // ▶
+        Button collapseRightBtn = new Button("\uf0da"); // ▶
+        collapseRightBtn.setFont(Font.font("FontAwesome", 14));
         collapseRightBtn.setStyle("-fx-background-color: transparent; -fx-cursor: hand; -fx-text-fill: white;");
         Pane rightSpacer = new Pane();
         HBox.setHgrow(rightSpacer, Priority.ALWAYS);
@@ -628,8 +631,9 @@ public class MainView extends AnchorPane {
     }
 
     private Button setupRightPanelShowButton(VBox layersPanel) {
-        Button showRightBtn = new Button("\u25C0"); // ◀
-        showRightBtn.setStyle("-fx-background-color: #2b2b2b; -fx-text-fill: white; -fx-background-radius: 8 0 0 8; -fx-padding: 10 5;");
+        Button showRightBtn = new Button("\uf0d9"); // ◀
+        showRightBtn.setFont(Font.font("FontAwesome", 14));
+        showRightBtn.setStyle("-fx-background-color: #2b2b2b; -fx-text-fill: white; -fx-background-radius: 8 0 0 8; -fx-padding: 10 5; -fx-cursor: hand;");
         showRightBtn.setVisible(false);
         AnchorPane.setTopAnchor(showRightBtn, 80.0);
         AnchorPane.setRightAnchor(showRightBtn, 0.0);

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -71,6 +71,7 @@ public class MainView extends AnchorPane {
     private ToggleButton enableKingdomOverlayToggle;
     private ToggleButton poiToggle;
     private ToggleButton labelsLayerToggle;
+    private ToggleButton riversLakesLayerToggle;
     private Tab kingdomsTab;
     
     private Slider dungeonDensitySlider;
@@ -568,6 +569,9 @@ public class MainView extends AnchorPane {
             if (i == 0) {
                 labelsLayerToggle = toggle;
             }
+            if (i == 4) {
+                riversLakesLayerToggle = toggle;
+            }
 
             row.getChildren().addAll(nameLabel, rowSpacer, toggle);
             layersPanel.getChildren().add(row);
@@ -687,6 +691,7 @@ public class MainView extends AnchorPane {
     public javafx.scene.shape.Rectangle getSelectedProvinceColorBox() { return selectedProvinceColorBox; }
 
     public ToggleButton getLabelsLayerToggle() { return labelsLayerToggle; }
+    public ToggleButton getRiversLakesLayerToggle() { return riversLakesLayerToggle; }
 
     private Image loadIcon(String resourcePath) {
         java.io.InputStream stream = getClass().getResourceAsStream(resourcePath);

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -260,13 +260,17 @@
 }
 
 #add-poi-toggle {
-    -fx-text-fill: black;
+    -fx-background-color: #d35400;
+    -fx-text-fill: #ffffff;
     -fx-font-weight: bold;
 }
+#add-poi-toggle:hover {
+    -fx-background-color: #e67e22;
+}
 #add-poi-toggle:selected {
-    -fx-background-color: #58d68d; /* light green so black text stays readable */
-    -fx-text-fill: black;
+    -fx-background-color: #27ae60;
+    -fx-text-fill: #ffffff;
 }
 #add-poi-toggle:selected:hover {
-    -fx-background-color: #6fe09e;
+    -fx-background-color: #2ecc71;
 }

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -258,6 +258,13 @@
 #province-paint-toggle:selected:hover {
     -fx-background-color: #2ecc71;
 }
+#province-paint-toggle.no-target:selected {
+    -fx-background-color: #d4ac0d; /* amber/yellow warning style */
+    -fx-text-fill: #ffffff;
+}
+#province-paint-toggle.no-target:selected:hover {
+    -fx-background-color: #f1c40f;
+}
 
 #add-poi-toggle {
     -fx-background-color: #d35400;

--- a/time-tracking.md
+++ b/time-tracking.md
@@ -16,6 +16,7 @@
 - 9.6.26 - 30 min - Created icons for ui
 - 9.6.26 - 30 min - Refactor ui and bugfix
 - 16.6.26 - 1,5 Hours - ui/ux, bugfixes, province layers, settings reset, icons
+- 20.6.26 - 1,5 Hours - Layers functionality, 
 
 # Lukas
 


### PR DESCRIPTION
### Description

Worked on #13 and some fixes

  Fixes layers panel toggles, implements map grid, adds paint stroke undo (Ctrl+Z), and updates UI layouts/button styling.

  ### Key Changes

  • Layers Panel Fixes:
      • Wired Labels and Rivers & Lakes visibility toggles to update render.
      • Implemented Grid overlay drawing (default OFF, clipped to map bounds).
      • Disabled POI interaction (dragging/editing) when POIs layer is hidden.
      • Removed unused toggles (Structures & Roads, Mountains).
  • Province Editing & Undo:
      • Implemented Ctrl+Z undo for province paint strokes (brush strokes & flood-fill annexation).
      • Added a small Ctrl+Z tip label in the Kingdoms panel.
  • UI & Button Polish:
      • Styled  + Add POI  button to match  Province Paint Mode  (orange default, green active).
      • Province paint button text/color now updates dynamically: green +  Start painting on map!  if target active; amber +  Select from provinces list!  if no target active.
      • Refactored side panels close/open arrows to use FontAwesome carets.
  • General:
      • Changed default application startup seed to  12345678 .