### PR TITLE
feat: grid settings tab, POI selection highlighting, and sidebar layout improvements

### DIFF
--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -73,6 +73,7 @@ public class MainPresenter {
     // POI editing
     private boolean addPoiMode = false;
     private PointOfInterest draggedPOI = null;
+    private PointOfInterest selectedPOI = null;
 
     public MainPresenter() {
         this.model = new MainModel();
@@ -250,12 +251,23 @@ public class MainPresenter {
             double y = event.getY();
             com.mapbuilder.mapbuilder.core.map.MapLabel clickedLabel = getLabelAt(x, y);
 
-            // Double-click on a POI marker opens its editor (takes priority)
-            if (event.getClickCount() == 2 && !provincePaintMode && !addPoiMode) {
+            // Handle POI interactions first (takes priority)
+            if (!provincePaintMode && !addPoiMode) {
                 PointOfInterest poiHit = getPOIAt(x, y);
                 if (poiHit != null) {
-                    openPOIEditor(poiHit);
+                    if (event.getButton() == javafx.scene.input.MouseButton.PRIMARY) {
+                        if (event.getClickCount() == 2) {
+                            openPOIEditor(poiHit);
+                        } else if (event.getClickCount() == 1) {
+                            selectPOI(poiHit, false);
+                        }
+                    }
                     return;
+                } else {
+                    // Clicked elsewhere on the map, deselect POI
+                    if (event.getButton() == javafx.scene.input.MouseButton.PRIMARY && event.getClickCount() == 1) {
+                        selectPOI(null, false);
+                    }
                 }
             }
 
@@ -1150,6 +1162,16 @@ public class MainPresenter {
                 );
             }
 
+            // Draw highlight square if selected
+            if (poi == selectedPOI) {
+                gc.save();
+                gc.setStroke(javafx.scene.paint.Color.WHITE);
+                gc.setLineWidth(1.5);
+                double highlightSide = spriteSize + 2.0;
+                gc.strokeRect(screenX - highlightSide / 2.0, screenY - highlightSide / 2.0, highlightSide, highlightSide);
+                gc.restore();
+            }
+
             if (showAllLabels) {
                 labelPositions.add(new double[]{screenX, screenY});
                 labelTexts.add(poi.getName());
@@ -1166,7 +1188,7 @@ public class MainPresenter {
             }
         }
 
-        // Render labels — all visible POIs at high zoom, or just the hovered one
+        // Render labels — all visible POIs at high zoom, or just the hovered/selected one
         if (showAllLabels && labelPositions != null) {
             gc.setFont(new Font("Arial", labelFontSize));
             for (int i = 0; i < labelPositions.size(); i++) {
@@ -1177,14 +1199,22 @@ public class MainPresenter {
                 gc.setFill(javafx.scene.paint.Color.WHITE);
                 gc.fillText(labelTexts.get(i), lx, ly);
             }
-        } else if (hoveredPOI != null) {
-            double labelX = (hoveredPOI.getX() - viewOffsetX) * pixelsPerCell;
-            double labelY = (hoveredPOI.getY() - viewOffsetY) * pixelsPerCell - 20;
-            gc.setFont(new Font("Arial", 11));
-            gc.setFill(javafx.scene.paint.Color.BLACK);
-            gc.fillText(hoveredPOI.getName(), labelX + 1, labelY + 1);
-            gc.setFill(javafx.scene.paint.Color.WHITE);
-            gc.fillText(hoveredPOI.getName(), labelX, labelY);
+        } else {
+            PointOfInterest labelPOI = hoveredPOI != null ? hoveredPOI : selectedPOI;
+            if (labelPOI != null) {
+                double screenX = (labelPOI.getX() - viewOffsetX) * pixelsPerCell;
+                double screenY = (labelPOI.getY() - viewOffsetY) * pixelsPerCell;
+                if (screenX >= -halfIcon && screenX < width + halfIcon &&
+                    screenY >= -halfIcon && screenY < height + halfIcon) {
+                    double labelX = screenX;
+                    double labelY = screenY - halfSprite - 4;
+                    gc.setFont(new Font("Arial", 11));
+                    gc.setFill(javafx.scene.paint.Color.BLACK);
+                    gc.fillText(labelPOI.getName(), labelX + 1, labelY + 1);
+                    gc.setFill(javafx.scene.paint.Color.WHITE);
+                    gc.fillText(labelPOI.getName(), labelX, labelY);
+                }
+            }
         }
     }
 
@@ -1202,6 +1232,49 @@ public class MainPresenter {
         return javafx.scene.paint.Color.color(r / 255.0, g / 255.0, b / 255.0, a / 255.0);
     }
     
+    /**
+     * Highlights and optionally centers viewport on the given POI.
+     * 
+     * @param poi The POI to highlight, or null to clear selection
+     * @param zoom Whether to center and zoom in on the POI
+     */
+    public void selectPOI(PointOfInterest poi, boolean zoom) {
+        if (poi == null) {
+            selectedPOI = null;
+            if (view != null && view.getPOIListPanel() != null) {
+                view.getPOIListPanel().selectPOI(null);
+            }
+            renderMap();
+            return;
+        }
+        
+        selectedPOI = poi;
+        
+        if (view != null) {
+            // Synchronize the sidebar list selection
+            if (view.getPOIListPanel() != null) {
+                view.getPOIListPanel().selectPOI(poi);
+            }
+            
+            if (zoom) {
+                // Adjust zoom to a reasonable level if currently zoomed out
+                if (pixelsPerCell < 3.0) {
+                    pixelsPerCell = 3.0;
+                }
+                
+                // Center viewport on the POI
+                double canvasW = view.getCanvas().getWidth();
+                double canvasH = view.getCanvas().getHeight();
+                if (canvasW > 0 && canvasH > 0) {
+                    viewOffsetX = poi.getX() - (canvasW / pixelsPerCell) / 2.0;
+                    viewOffsetY = poi.getY() - (canvasH / pixelsPerCell) / 2.0;
+                }
+            }
+        }
+        
+        renderMap();
+    }
+
     /**
      * Opens the POI editor modal dialog for the given POI.
      * 
@@ -1236,6 +1309,10 @@ public class MainPresenter {
      */
     public void deletePOI(PointOfInterest poi) {
         if (poi == null) return;
+        
+        if (poi == selectedPOI) {
+            selectedPOI = null;
+        }
         
         MapGrid grid = model.getCurrentGrid();
         if (grid == null) return;

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -235,6 +235,15 @@ public class MainPresenter {
         view.getRiversLakesLayerToggle().selectedProperty().addListener((obs, oldV, newV) -> regenerateImages());
         view.getLabelsLayerToggle().selectedProperty().addListener((obs, oldV, newV) -> renderMap());
         view.getGridLayerToggle().selectedProperty().addListener((obs, oldV, newV) -> renderMap());
+        view.getGridTypeComboBox().valueProperty().addListener((obs, oldV, newV) -> {
+            if (view.getGridLayerToggle().isSelected()) renderMap();
+        });
+        view.getGridSizeSlider().valueProperty().addListener((obs, oldV, newV) -> {
+            if (view.getGridLayerToggle().isSelected()) renderMap();
+        });
+        view.getGridOpacitySlider().valueProperty().addListener((obs, oldV, newV) -> {
+            if (view.getGridLayerToggle().isSelected()) renderMap();
+        });
 
         view.getCanvasContainer().setOnMouseClicked(event -> {
             double x = event.getX();
@@ -513,6 +522,10 @@ public class MainPresenter {
         view.getDungeonDensitySlider().setValue(0.3);
         view.getSettlementDensitySlider().setValue(0.3);
         view.getRuinCastleDensitySlider().setValue(0.3);
+        // Grid Options
+        view.getGridTypeComboBox().setValue("Square");
+        view.getGridSizeSlider().setValue(1);
+        view.getGridOpacitySlider().setValue(15);
         triggerGeneration();
     }
 
@@ -680,34 +693,82 @@ public class MainPresenter {
 
         // ── Grid overlay ──────────────────────────────────────────────────
         if (view.getGridLayerToggle().isSelected()) {
-            gc.setStroke(javafx.scene.paint.Color.color(1, 1, 1, 0.15));
+            String gridType = view.getGridTypeComboBox().getValue();
+            int gridSize = (int) view.getGridSizeSlider().getValue();
+            double opacity = view.getGridOpacitySlider().getValue() / 100.0;
+
+            gc.setStroke(javafx.scene.paint.Color.color(1, 1, 1, opacity));
             gc.setLineWidth(0.5);
+
             int gridW = baseGrid.getWidth();
             int gridH = baseGrid.getHeight();
+
             // Map bounding box in screen coordinates
             double mapScreenX0 = (0 - viewOffsetX) * pixelsPerCell;
             double mapScreenY0 = (0 - viewOffsetY) * pixelsPerCell;
             double mapScreenX1 = (gridW - viewOffsetX) * pixelsPerCell;
             double mapScreenY1 = (gridH - viewOffsetY) * pixelsPerCell;
+
             // Clamp to canvas
             double clipTop    = Math.max(0, mapScreenY0);
             double clipBottom  = Math.min(canvasH, mapScreenY1);
             double clipLeft   = Math.max(0, mapScreenX0);
             double clipRight  = Math.min(canvasW, mapScreenX1);
-            // Vertical lines
-            int startCellX = Math.max(0, (int) viewOffsetX);
-            int endCellX = Math.min(gridW, (int) (viewOffsetX + canvasW / pixelsPerCell) + 1);
-            for (int cx = startCellX; cx <= endCellX; cx++) {
-                double sx = (cx - viewOffsetX) * pixelsPerCell;
-                gc.strokeLine(sx, clipTop, sx, clipBottom);
+
+            gc.save();
+            gc.beginPath();
+            gc.rect(clipLeft, clipTop, clipRight - clipLeft, clipBottom - clipTop);
+            gc.clip();
+
+            if ("Hexagon".equals(gridType)) {
+                double R_map = gridSize;
+                double R_screen = R_map * pixelsPerCell;
+                double width_screen = R_screen * Math.sqrt(3);
+                double colSpacing = width_screen;
+                double rowSpacing = 1.5 * R_screen;
+                double h = colSpacing / 2.0;
+
+                int minRow = Math.max(-1, (int) (viewOffsetY / (1.5 * R_map)) - 1);
+                int maxRow = Math.min((int) (gridH / (1.5 * R_map)) + 1, (int) ((viewOffsetY + canvasH / pixelsPerCell) / (1.5 * R_map)) + 1);
+
+                int minCol = Math.max(-1, (int) (viewOffsetX / (Math.sqrt(3) * R_map)) - 2);
+                int maxCol = Math.min((int) (gridW / (Math.sqrt(3) * R_map)) + 1, (int) ((viewOffsetX + canvasW / pixelsPerCell) / (Math.sqrt(3) * R_map)) + 2);
+
+                for (int r = minRow; r <= maxRow; r++) {
+                    for (int c = minCol; c <= maxCol; c++) {
+                        double cx = (c * colSpacing) - viewOffsetX * pixelsPerCell;
+                        if (r % 2 != 0) {
+                            cx += colSpacing / 2.0;
+                        }
+                        double cy = (r * rowSpacing) - viewOffsetY * pixelsPerCell;
+
+                        // Top-left segment
+                        gc.strokeLine(cx, cy - R_screen, cx - h, cy - R_screen / 2.0);
+                        // Top-right segment
+                        gc.strokeLine(cx, cy - R_screen, cx + h, cy - R_screen / 2.0);
+                        // Left vertical segment
+                        gc.strokeLine(cx - h, cy - R_screen / 2.0, cx - h, cy + R_screen / 2.0);
+                    }
+                }
+            } else {
+                // Vertical lines
+                int startCellX = Math.max(0, (int) viewOffsetX);
+                int endCellX = Math.min(gridW, (int) (viewOffsetX + canvasW / pixelsPerCell) + 1);
+                startCellX = startCellX - (startCellX % gridSize);
+                for (int cx = startCellX; cx <= endCellX; cx += gridSize) {
+                    double sx = (cx - viewOffsetX) * pixelsPerCell;
+                    gc.strokeLine(sx, mapScreenY0, sx, mapScreenY1);
+                }
+                // Horizontal lines
+                int startCellY = Math.max(0, (int) viewOffsetY);
+                int endCellY = Math.min(gridH, (int) (viewOffsetY + canvasH / pixelsPerCell) + 1);
+                startCellY = startCellY - (startCellY % gridSize);
+                for (int cy = startCellY; cy <= endCellY; cy += gridSize) {
+                    double sy = (cy - viewOffsetY) * pixelsPerCell;
+                    gc.strokeLine(mapScreenX0, sy, mapScreenX1, sy);
+                }
             }
-            // Horizontal lines
-            int startCellY = Math.max(0, (int) viewOffsetY);
-            int endCellY = Math.min(gridH, (int) (viewOffsetY + canvasH / pixelsPerCell) + 1);
-            for (int cy = startCellY; cy <= endCellY; cy++) {
-                double sy = (cy - viewOffsetY) * pixelsPerCell;
-                gc.strokeLine(clipLeft, sy, clipRight, sy);
-            }
+            gc.restore();
         }
 
         renderPOIs();

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -1253,7 +1253,7 @@ public class MainPresenter {
         if (view != null) {
             // Synchronize the sidebar list selection
             if (view.getPOIListPanel() != null) {
-                view.getPOIListPanel().selectPOI(poi);
+                view.getPOIListPanel().selectPOI(poi, !zoom);
             }
             
             if (zoom) {

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainPresenter.java
@@ -524,8 +524,8 @@ public class MainPresenter {
         view.getRuinCastleDensitySlider().setValue(0.3);
         // Grid Options
         view.getGridTypeComboBox().setValue("Square");
-        view.getGridSizeSlider().setValue(1);
-        view.getGridOpacitySlider().setValue(15);
+        view.getGridSizeSlider().setValue(7);
+        view.getGridOpacitySlider().setValue(25);
         triggerGeneration();
     }
 

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -384,14 +384,14 @@ public class MainView extends AnchorPane {
         gridTypeComboBox.setValue("Square");
         gridTypeComboBox.setMaxWidth(Double.MAX_VALUE);
 
-        gridSizeSlider = new Slider(1, 10, 1);
+        gridSizeSlider = new Slider(1, 10, 7);
         gridSizeSlider.setShowTickMarks(true);
         gridSizeSlider.setShowTickLabels(true);
         gridSizeSlider.setMajorTickUnit(1);
         gridSizeSlider.setMinorTickCount(0);
         gridSizeSlider.setSnapToTicks(true);
 
-        gridOpacitySlider = new Slider(0, 100, 15);
+        gridOpacitySlider = new Slider(0, 100, 25);
         gridOpacitySlider.setShowTickMarks(true);
         gridOpacitySlider.setShowTickLabels(true);
         gridOpacitySlider.setMajorTickUnit(50);

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -324,7 +324,38 @@ public class MainView extends AnchorPane {
 
         poisTab.setContent(poisContent);
 
-        TabPane tabPane = new TabPane(terrainTab, hydrologyTab, kingdomsTab, poisTab);
+        // Create Grid Tab
+        Tab gridTab = new Tab("Grid");
+        gridTab.setClosable(false);
+        gridTab.setStyle("-fx-text-fill: white;");
+        VBox gridContent = new VBox(10);
+        gridContent.setPadding(new Insets(10, 0, 10, 0));
+
+        gridTypeComboBox = new javafx.scene.control.ComboBox<>();
+        gridTypeComboBox.getItems().addAll("Square", "Hexagon");
+        gridTypeComboBox.setValue("Square");
+        gridTypeComboBox.setMaxWidth(Double.MAX_VALUE);
+
+        gridSizeSlider = new Slider(1, 10, 7);
+        gridSizeSlider.setShowTickMarks(true);
+        gridSizeSlider.setShowTickLabels(true);
+        gridSizeSlider.setMajorTickUnit(1);
+        gridSizeSlider.setMinorTickCount(0);
+        gridSizeSlider.setSnapToTicks(true);
+
+        gridOpacitySlider = new Slider(0, 100, 25);
+        gridOpacitySlider.setShowTickMarks(true);
+        gridOpacitySlider.setShowTickLabels(true);
+        gridOpacitySlider.setMajorTickUnit(50);
+
+        gridContent.getChildren().addAll(
+            new Label("Grid Type"), gridTypeComboBox,
+            new Label("Grid Cell Size (Cells)"), gridSizeSlider,
+            new Label("Grid Opacity (%)"), gridOpacitySlider
+        );
+        gridTab.setContent(gridContent);
+
+        TabPane tabPane = new TabPane(terrainTab, hydrologyTab, kingdomsTab, poisTab, gridTab);
         tabPane.setStyle("-fx-background-color: #2b2b2b; " +
                 "-fx-control-inner-background: #2b2b2b; " +
                 "-fx-tab-header-background: #2b2b2b; " +
@@ -379,23 +410,6 @@ public class MainView extends AnchorPane {
         rainBiasSlider.setShowTickLabels(true);
         rainBiasSlider.setMajorTickUnit(0.25);
 
-        gridTypeComboBox = new javafx.scene.control.ComboBox<>();
-        gridTypeComboBox.getItems().addAll("Square", "Hexagon");
-        gridTypeComboBox.setValue("Square");
-        gridTypeComboBox.setMaxWidth(Double.MAX_VALUE);
-
-        gridSizeSlider = new Slider(1, 10, 7);
-        gridSizeSlider.setShowTickMarks(true);
-        gridSizeSlider.setShowTickLabels(true);
-        gridSizeSlider.setMajorTickUnit(1);
-        gridSizeSlider.setMinorTickCount(0);
-        gridSizeSlider.setSnapToTicks(true);
-
-        gridOpacitySlider = new Slider(0, 100, 25);
-        gridOpacitySlider.setShowTickMarks(true);
-        gridOpacitySlider.setShowTickLabels(true);
-        gridOpacitySlider.setMajorTickUnit(50);
-
         Label mapSizeLabel = new Label("Map Size"); mapSizeLabel.setStyle("-fx-text-fill: white;");
         Label octavesLabel = new Label("Octaves (Detail Level)"); octavesLabel.setStyle("-fx-text-fill: white;");
         Label scaleLabel = new Label("Scale (Zoom Level)"); scaleLabel.setStyle("-fx-text-fill: white;");
@@ -404,11 +418,6 @@ public class MainView extends AnchorPane {
         Label tempBiasLabel = new Label("Temperature Bias"); tempBiasLabel.setStyle("-fx-text-fill: white;");
         Label rainBiasLabel = new Label("Rainfall Bias"); rainBiasLabel.setStyle("-fx-text-fill: white;");
 
-        Label gridTitle = new Label("Grid Options"); gridTitle.setStyle("-fx-text-fill: white; -fx-font-weight: bold; -fx-padding: 10 0 0 0;");
-        Label gridTypeLabel = new Label("Grid Type"); gridTypeLabel.setStyle("-fx-text-fill: white;");
-        Label gridSizeLabel = new Label("Grid Cell Size (Cells)"); gridSizeLabel.setStyle("-fx-text-fill: white;");
-        Label gridOpacityLabel = new Label("Grid Opacity (%)"); gridOpacityLabel.setStyle("-fx-text-fill: white;");
-
         terrainContent.getChildren().addAll(
             mapSizeLabel, sizeSlider,
             octavesLabel, octavesSlider,
@@ -416,12 +425,7 @@ public class MainView extends AnchorPane {
             falloffLabel, falloffSlider,
             seaLevelLabel, waterLevelSlider,
             tempBiasLabel, tempBiasSlider,
-            rainBiasLabel, rainBiasSlider,
-            new Separator(),
-            gridTitle,
-            gridTypeLabel, gridTypeComboBox,
-            gridSizeLabel, gridSizeSlider,
-            gridOpacityLabel, gridOpacitySlider
+            rainBiasLabel, rainBiasSlider
         );
         terrainTab.setContent(terrainContent);
         

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -74,6 +74,9 @@ public class MainView extends AnchorPane {
     private ToggleButton riversLakesLayerToggle;
     private ToggleButton gridLayerToggle;
     private Tab kingdomsTab;
+    private javafx.scene.control.ComboBox<String> gridTypeComboBox;
+    private Slider gridSizeSlider;
+    private Slider gridOpacitySlider;
     
     private Slider dungeonDensitySlider;
     private Slider settlementDensitySlider;
@@ -376,6 +379,23 @@ public class MainView extends AnchorPane {
         rainBiasSlider.setShowTickLabels(true);
         rainBiasSlider.setMajorTickUnit(0.25);
 
+        gridTypeComboBox = new javafx.scene.control.ComboBox<>();
+        gridTypeComboBox.getItems().addAll("Square", "Hexagon");
+        gridTypeComboBox.setValue("Square");
+        gridTypeComboBox.setMaxWidth(Double.MAX_VALUE);
+
+        gridSizeSlider = new Slider(1, 10, 1);
+        gridSizeSlider.setShowTickMarks(true);
+        gridSizeSlider.setShowTickLabels(true);
+        gridSizeSlider.setMajorTickUnit(1);
+        gridSizeSlider.setMinorTickCount(0);
+        gridSizeSlider.setSnapToTicks(true);
+
+        gridOpacitySlider = new Slider(0, 100, 15);
+        gridOpacitySlider.setShowTickMarks(true);
+        gridOpacitySlider.setShowTickLabels(true);
+        gridOpacitySlider.setMajorTickUnit(50);
+
         Label mapSizeLabel = new Label("Map Size"); mapSizeLabel.setStyle("-fx-text-fill: white;");
         Label octavesLabel = new Label("Octaves (Detail Level)"); octavesLabel.setStyle("-fx-text-fill: white;");
         Label scaleLabel = new Label("Scale (Zoom Level)"); scaleLabel.setStyle("-fx-text-fill: white;");
@@ -384,6 +404,11 @@ public class MainView extends AnchorPane {
         Label tempBiasLabel = new Label("Temperature Bias"); tempBiasLabel.setStyle("-fx-text-fill: white;");
         Label rainBiasLabel = new Label("Rainfall Bias"); rainBiasLabel.setStyle("-fx-text-fill: white;");
 
+        Label gridTitle = new Label("Grid Options"); gridTitle.setStyle("-fx-text-fill: white; -fx-font-weight: bold; -fx-padding: 10 0 0 0;");
+        Label gridTypeLabel = new Label("Grid Type"); gridTypeLabel.setStyle("-fx-text-fill: white;");
+        Label gridSizeLabel = new Label("Grid Cell Size (Cells)"); gridSizeLabel.setStyle("-fx-text-fill: white;");
+        Label gridOpacityLabel = new Label("Grid Opacity (%)"); gridOpacityLabel.setStyle("-fx-text-fill: white;");
+
         terrainContent.getChildren().addAll(
             mapSizeLabel, sizeSlider,
             octavesLabel, octavesSlider,
@@ -391,7 +416,12 @@ public class MainView extends AnchorPane {
             falloffLabel, falloffSlider,
             seaLevelLabel, waterLevelSlider,
             tempBiasLabel, tempBiasSlider,
-            rainBiasLabel, rainBiasSlider
+            rainBiasLabel, rainBiasSlider,
+            new Separator(),
+            gridTitle,
+            gridTypeLabel, gridTypeComboBox,
+            gridSizeLabel, gridSizeSlider,
+            gridOpacityLabel, gridOpacitySlider
         );
         terrainTab.setContent(terrainContent);
         
@@ -701,6 +731,10 @@ public class MainView extends AnchorPane {
     public ToggleButton getLabelsLayerToggle() { return labelsLayerToggle; }
     public ToggleButton getRiversLakesLayerToggle() { return riversLakesLayerToggle; }
     public ToggleButton getGridLayerToggle()        { return gridLayerToggle; }
+
+    public javafx.scene.control.ComboBox<String> getGridTypeComboBox() { return gridTypeComboBox; }
+    public Slider getGridSizeSlider() { return gridSizeSlider; }
+    public Slider getGridOpacitySlider() { return gridOpacitySlider; }
 
     private Image loadIcon(String resourcePath) {
         java.io.InputStream stream = getClass().getResourceAsStream(resourcePath);

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -145,7 +145,7 @@ public class MainView extends AnchorPane {
 
     private ScrollPane setupLeftPanel() {
         VBox leftPanel = new VBox(10);
-        leftPanel.setPrefWidth(300);
+        leftPanel.setPrefWidth(340);
         leftPanel.setPadding(new Insets(15));
         leftPanel.setStyle("-fx-background-color: #2b2b2b; -fx-background-radius: 0;");
         leftPanel.getStyleClass().add("left-panel");
@@ -376,7 +376,7 @@ public class MainView extends AnchorPane {
         sizeSlider = new Slider(200, 2000, 800);
         sizeSlider.setShowTickMarks(true);
         sizeSlider.setShowTickLabels(true);
-        sizeSlider.setMajorTickUnit(400);
+        sizeSlider.setMajorTickUnit(600);
 
         octavesSlider = new Slider(1, 10, 5);
         octavesSlider.setShowTickMarks(true);
@@ -471,7 +471,7 @@ public class MainView extends AnchorPane {
         Button collapseLeftBtn = (Button) leftScroll.getProperties().get("collapseLeftBtn");
         collapseLeftBtn.setOnAction(e -> {
             TranslateTransition tt = new TranslateTransition(Duration.millis(300), leftScroll);
-            tt.setToX(-320);
+            tt.setToX(-360);
             tt.setOnFinished(evt -> showLeftBtn.setVisible(true));
             tt.play();
         });

--- a/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/main/MainView.java
@@ -145,7 +145,7 @@ public class MainView extends AnchorPane {
 
     private ScrollPane setupLeftPanel() {
         VBox leftPanel = new VBox(10);
-        leftPanel.setPrefWidth(280);
+        leftPanel.setPrefWidth(300);
         leftPanel.setPadding(new Insets(15));
         leftPanel.setStyle("-fx-background-color: #2b2b2b; -fx-background-radius: 0;");
         leftPanel.getStyleClass().add("left-panel");
@@ -471,7 +471,7 @@ public class MainView extends AnchorPane {
         Button collapseLeftBtn = (Button) leftScroll.getProperties().get("collapseLeftBtn");
         collapseLeftBtn.setOnAction(e -> {
             TranslateTransition tt = new TranslateTransition(Duration.millis(300), leftScroll);
-            tt.setToX(-300);
+            tt.setToX(-320);
             tt.setOnFinished(evt -> showLeftBtn.setVisible(true));
             tt.play();
         });

--- a/src/main/java/com/mapbuilder/mapbuilder/ui/POIListPanel.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/ui/POIListPanel.java
@@ -120,22 +120,90 @@ public class POIListPanel extends VBox {
         if (pois == null) {
             poiListView.setItems(FXCollections.emptyObservableList());
         } else {
-            poiListView.setItems(FXCollections.observableArrayList(pois));
+            List<PointOfInterest> sortedPois = new java.util.ArrayList<>(pois);
+            sortedPois.sort((p1, p2) -> {
+                String t1 = p1.getType() != null ? p1.getType().toString() : "";
+                String t2 = p2.getType() != null ? p2.getType().toString() : "";
+                int typeComp = t1.compareTo(t2);
+                if (typeComp != 0) {
+                    return typeComp;
+                }
+                String n1 = p1.getName() != null ? p1.getName() : "";
+                String n2 = p2.getName() != null ? p2.getName() : "";
+                return compareNatural(n1, n2);
+            });
+            poiListView.setItems(FXCollections.observableArrayList(sortedPois));
         }
+    }
+
+    public void selectPOI(PointOfInterest poi) {
+        selectPOI(poi, false);
     }
 
     /**
      * Programmatically selects a POI in the list view.
      * 
      * @param poi The POI to select, or null to clear selection
+     * @param scrollTo Whether to scroll the selected POI into view
      */
-    public void selectPOI(PointOfInterest poi) {
+    public void selectPOI(PointOfInterest poi, boolean scrollTo) {
         if (poi == null) {
             poiListView.getSelectionModel().clearSelection();
         } else {
             poiListView.getSelectionModel().select(poi);
-            poiListView.scrollTo(poi);
+            if (scrollTo) {
+                poiListView.scrollTo(poi);
+            }
         }
+    }
+
+    /**
+     * Performs a natural alphanumeric comparison between two strings.
+     * 
+     * @param s1 First string
+     * @param s2 Second string
+     * @return comparison result
+     */
+    private static int compareNatural(String s1, String s2) {
+        int len1 = s1.length();
+        int len2 = s2.length();
+        int i = 0, j = 0;
+        while (i < len1 && j < len2) {
+            char c1 = s1.charAt(i);
+            char c2 = s2.charAt(j);
+            if (Character.isDigit(c1) && Character.isDigit(c2)) {
+                int start1 = i;
+                while (i < len1 && Character.isDigit(s1.charAt(i))) {
+                    i++;
+                }
+                int start2 = j;
+                while (j < len2 && Character.isDigit(s2.charAt(j))) {
+                    j++;
+                }
+                String numStr1 = s1.substring(start1, i);
+                String numStr2 = s2.substring(start2, j);
+                try {
+                    long n1 = Long.parseLong(numStr1);
+                    long n2 = Long.parseLong(numStr2);
+                    int comp = Long.compare(n1, n2);
+                    if (comp != 0) {
+                        return comp;
+                    }
+                } catch (NumberFormatException e) {
+                    int comp = numStr1.compareTo(numStr2);
+                    if (comp != 0) {
+                        return comp;
+                    }
+                }
+            } else {
+                if (c1 != c2) {
+                    return Character.compare(c1, c2);
+                }
+                i++;
+                j++;
+            }
+        }
+        return Integer.compare(len1 - i, len2 - j);
     }
     
     /**

--- a/src/main/java/com/mapbuilder/mapbuilder/ui/POIListPanel.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/ui/POIListPanel.java
@@ -60,7 +60,7 @@ public class POIListPanel extends VBox {
             @Override
             protected void updateItem(PointOfInterest poi, boolean empty) {
                 super.updateItem(poi, empty);
-                setStyle("-fx-background-color: #1e1e1e; -fx-text-fill: white;");
+                setStyle("-fx-background-color: transparent; -fx-text-fill: white;");
                 if (empty || poi == null) {
                     setText(null);
                     setGraphic(null);
@@ -68,7 +68,7 @@ public class POIListPanel extends VBox {
                     // Create HBox with icon color square + name + coordinates
                     HBox cell = new HBox(5);
                     cell.setAlignment(Pos.CENTER_LEFT);
-                    cell.setStyle("-fx-background-color: #1e1e1e;");
+                    cell.setStyle("-fx-background-color: transparent;");
                     
                     // Color square (16x16px, type color)
                     Rectangle colorSquare = new Rectangle(16, 16);
@@ -80,7 +80,6 @@ public class POIListPanel extends VBox {
                     String displayText = String.format("%s (%s)", 
                         poi.getName(), poi.getType());
                     Label label = new Label(displayText);
-                    label.setStyle("-fx-text-fill: #e0e0e0;");
                     
                     cell.getChildren().addAll(colorSquare, label);
                     setGraphic(cell);
@@ -88,11 +87,15 @@ public class POIListPanel extends VBox {
             }
         });
         
-        // Handle selection: click to open editor
+        // Handle selection: single click to zoom/highlight, double click to edit
         poiListView.setOnMouseClicked(event -> {
             PointOfInterest selected = poiListView.getSelectionModel().getSelectedItem();
             if (selected != null && presenter != null) {
-                presenter.openPOIEditor(selected);
+                if (event.getClickCount() == 2) {
+                    presenter.openPOIEditor(selected);
+                } else if (event.getClickCount() == 1) {
+                    presenter.selectPOI(selected, true);
+                }
             }
         });
         
@@ -118,6 +121,20 @@ public class POIListPanel extends VBox {
             poiListView.setItems(FXCollections.emptyObservableList());
         } else {
             poiListView.setItems(FXCollections.observableArrayList(pois));
+        }
+    }
+
+    /**
+     * Programmatically selects a POI in the list view.
+     * 
+     * @param poi The POI to select, or null to clear selection
+     */
+    public void selectPOI(PointOfInterest poi) {
+        if (poi == null) {
+            poiListView.getSelectionModel().clearSelection();
+        } else {
+            poiListView.getSelectionModel().select(poi);
+            poiListView.scrollTo(poi);
         }
     }
     

--- a/src/main/java/com/mapbuilder/mapbuilder/ui/ProvinceListPanel.java
+++ b/src/main/java/com/mapbuilder/mapbuilder/ui/ProvinceListPanel.java
@@ -62,7 +62,7 @@ public class ProvinceListPanel extends VBox {
             @Override
             protected void updateItem(Kingdom k, boolean empty) {
                 super.updateItem(k, empty);
-                setStyle("-fx-background-color: #1e1e1e;");
+                setStyle("-fx-background-color: transparent;");
                 if (empty || k == null) {
                     setText(null);
                     setGraphic(null);
@@ -71,7 +71,7 @@ public class ProvinceListPanel extends VBox {
 
                 HBox row = new HBox(8);
                 row.setAlignment(Pos.CENTER_LEFT);
-                row.setStyle("-fx-background-color: #1e1e1e;");
+                row.setStyle("-fx-background-color: transparent;");
 
                 // Colour swatch — acts as the clickable colour button
                 Rectangle swatch = new Rectangle(16, 16);
@@ -116,7 +116,6 @@ public class ProvinceListPanel extends VBox {
 
                 // Province name
                 Label nameLabel = new Label(k.getName());
-                nameLabel.setStyle("-fx-text-fill: #e0e0e0;");
                 HBox.setHgrow(nameLabel, Priority.ALWAYS);
 
                 row.getChildren().addAll(swatchPane, nameLabel);

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -300,3 +300,35 @@
 #add-poi-toggle:selected:hover {
     -fx-background-color: #2ecc71;
 }
+
+/* List views and cells styling */
+.list-view {
+    -fx-background-color: #1e1e1e;
+    -fx-background-insets: 0;
+    -fx-padding: 0;
+}
+.list-view .list-cell {
+    -fx-background-color: #1e1e1e;
+    -fx-text-fill: #e0e0e0;
+}
+.list-view .list-cell:filled:hover {
+    -fx-background-color: #2b2b2b;
+    -fx-text-fill: #ffffff;
+}
+.list-view .list-cell:filled:selected {
+    -fx-background-color: #3c3f41;
+    -fx-text-fill: #ffffff;
+}
+.list-view .list-cell:filled:selected:hover {
+    -fx-background-color: #4c4f51;
+    -fx-text-fill: #ffffff;
+}
+.list-view .list-cell .label {
+    -fx-text-fill: #e0e0e0;
+}
+.list-view .list-cell:filled:hover .label {
+    -fx-text-fill: #ffffff;
+}
+.list-view .list-cell:filled:selected .label {
+    -fx-text-fill: #ffffff;
+}

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -136,26 +136,45 @@
 .dialog-pane .text-area .content {
     -fx-background-color: #3c3f41;
 }
-.dialog-pane .combo-box {
+.combo-box {
     -fx-background-color: #3c3f41;
     -fx-border-color: #555555;
     -fx-border-radius: 3;
     -fx-background-radius: 3;
 }
-.dialog-pane .combo-box .list-cell {
+.combo-box:focused {
+    -fx-border-color: #777777;
+    -fx-focus-color: transparent;
+    -fx-faint-focus-color: transparent;
+}
+.combo-box .list-cell {
     -fx-background-color: #3c3f41;
     -fx-text-fill: #ffffff;
 }
-.dialog-pane .combo-box-popup .list-view {
+.combo-box .arrow-button {
+    -fx-background-color: transparent;
+}
+.combo-box .arrow {
+    -fx-background-color: #ffffff;
+}
+.combo-box-popup .list-view {
     -fx-background-color: #3c3f41;
     -fx-border-color: #555555;
 }
-.dialog-pane .combo-box-popup .list-cell {
+.combo-box-popup .list-view .list-cell {
     -fx-background-color: #3c3f41;
     -fx-text-fill: #ffffff;
 }
-.dialog-pane .combo-box-popup .list-cell:hover {
+.combo-box-popup .list-view .list-cell:hover {
     -fx-background-color: #4c4f51;
+}
+.combo-box-popup .list-view .list-cell:filled:selected {
+    -fx-background-color: #4c4f51;
+    -fx-text-fill: #ffffff;
+}
+.combo-box-popup .list-view .list-cell:filled:selected:hover {
+    -fx-background-color: #5c5f61;
+    -fx-text-fill: #ffffff;
 }
 .dialog-pane > .label {
     -fx-text-fill: #e0e0e0;

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -331,4 +331,5 @@
 }
 .list-view .list-cell:filled:selected .label {
     -fx-text-fill: #ffffff;
+    -fx-font-weight: bold;
 }


### PR DESCRIPTION
This branch adds grid rendering configurations, resolves sidebar layout constraints, and implements POI selection highlighting.

worked on: #1 

  ### Changes

  #### Grid Rendering Control
      • Added a new "Grid" tab.
      • Implemented type toggles for Square and Hexagon grid styles.
      • Added sliders for customizing cell size (1–10) and grid line opacity (0–100%).
  #### Sidebar Layout & Styles
      • Widened the collapsible left sidebar from 280px to 340px to fit all tab headers.
      • Re-spaced the Map Size slider tick units from 400 to 600 to prevent text overlap.
      • Themed all combo boxes and dropdown lists to match the dark stylesheet.
      • Configured list view cell stylesheets to turn text white and bold when items are selected or hovered.
  #### POI Selection & Highlighting
      • Single-clicking a POI on the map highlights it with a white square border.
      • Selecting a POI from the sidebar list highlights it, centers the map viewport, and soft-zooms (3.0 cells per pixel).
      • Skips list view scrolling when selection is initiated from the list itself to prevent UI shifting during double-clicks.
      • Double-clicking a POI in either the map or list opens the editor.
      • Implemented natural alphanumeric sorting in the POI list (e.g., sorting "Hamlet 2" before "Hamlet 16").